### PR TITLE
Remove 0.5*timestep logic from call to zm

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,31 @@
+
+===============================================================
+
+Tag name: atmos_phys0_04_001
+Originator(s): cacraig
+Date: Aug 15, 2024
+One-line Summary: Remove 0.5*timestep logic from call to zm
+Github PR URL: https://github.com/ESCOMP/atmospheric_physics/pull/109
+
+This PR fixes the following NCAR/atmospheric_physics Github issues:
+none
+
+Code reviewed by: adamrher, peverwhee
+
+List all existing files that have been added (A), modified (M), or deleted (D),
+and describe the changes:
+M       zhang_mcfarlane/zm_conv_convtran.F90
+M       zhang_mcfarlane/zm_conv_convtran.meta
+M       zhang_mcfarlane/zm_conv_momtran.F90
+M       zhang_mcfarlane/zm_convr.F90
+          - remove all the modifications that were being done because 0.5*timestep was being passed in
+
+List and Describe any test failures: N/A
+
+Summarize any changes to answers:
+Adam Herrington ran with these changes and determined they were roundoff (see PR for more details)
+
+===============================================================
 ===============================================================
 
 Tag name: atmos_phys0_03_00

--- a/zhang_mcfarlane/zm_conv_convtran.F90
+++ b/zhang_mcfarlane/zm_conv_convtran.F90
@@ -22,7 +22,7 @@ subroutine zm_conv_convtran_run(ncol, pver, &
                     doconvtran,q       ,ncnst   ,mu      ,md      , &
                     du      ,eu      ,ed      ,dp      ,dsubcld , &
                     jt      ,mx      ,ideep   ,il1g    ,il2g    , &
-                    nstep   ,fracis  ,dqdt    ,dpdry   ,dt      )
+                    nstep   ,fracis  ,dqdt    ,dpdry)
 !-----------------------------------------------------------------------
 !
 ! Purpose:
@@ -67,9 +67,6 @@ subroutine zm_conv_convtran_run(ncol, pver, &
    integer, intent(in) :: nstep          ! Time step index
 
    real(kind_phys), intent(in) :: dpdry(:,:)    ! Delta pressure between interfaces        (ncol,pver)
-
-   real(kind_phys), intent(in) :: dt                      ! 2 delta t (model time increment)
-
 
 ! input/output
 

--- a/zhang_mcfarlane/zm_conv_convtran.meta
+++ b/zhang_mcfarlane/zm_conv_convtran.meta
@@ -131,9 +131,3 @@
   type = real | kind = kind_phys
   dimensions = (1:horizontal_loop_extent,1:vertical_layer_dimension)
   intent = in
-[ dt ]
-  standard_name = timestep_for_physics
-  units = s
-  type = real | kind = kind_phys
-  dimensions = ()
-  intent = in

--- a/zhang_mcfarlane/zm_conv_momtran.F90
+++ b/zhang_mcfarlane/zm_conv_momtran.F90
@@ -59,7 +59,7 @@ subroutine zm_conv_momtran_run(ncol, pver, pverp, &
    real(kind_phys), intent(in) :: ed(:,:)       ! Mass entraining from downdraft            (ncol,pver)
    real(kind_phys), intent(in) :: dp(:,:)       ! Delta pressure between interfaces         (ncol,pver)
    real(kind_phys), intent(in) :: dsubcld(:)       ! Delta pressure from cloud base to sfc  (ncol)
-   real(kind_phys), intent(in) :: dt                   !  time step in seconds : 2*delta_t
+   real(kind_phys), intent(in) :: dt
 
    integer, intent(in) :: jt(:)         ! Index of cloud top for each column         (ncol)
    integer, intent(in) :: mx(:)         ! Index of cloud top for each column         (ncol)
@@ -415,7 +415,7 @@ subroutine zm_conv_momtran_run(ncol, pver, pverp, &
           ketend_cons = (fket-fkeb)/dp(i,k)
 
           ! tendency in kinetic energy resulting from the momentum transport
-          ketend = ((windf(i,k,1)**2 + windf(i,k,2)**2) - (wind0(i,k,1)**2 + wind0(i,k,2)**2))*0.5_kind_phys/dt
+          ketend = ((windf(i,k,1)**2 + windf(i,k,2)**2) - (wind0(i,k,1)**2 + wind0(i,k,2)**2))/dt
 
           ! the difference should be the dissipation
           gset2 = ketend_cons - ketend

--- a/zhang_mcfarlane/zm_conv_momtran.F90
+++ b/zhang_mcfarlane/zm_conv_momtran.F90
@@ -59,7 +59,7 @@ subroutine zm_conv_momtran_run(ncol, pver, pverp, &
    real(kind_phys), intent(in) :: ed(:,:)       ! Mass entraining from downdraft            (ncol,pver)
    real(kind_phys), intent(in) :: dp(:,:)       ! Delta pressure between interfaces         (ncol,pver)
    real(kind_phys), intent(in) :: dsubcld(:)       ! Delta pressure from cloud base to sfc  (ncol)
-   real(kind_phys), intent(in) :: dt
+   real(kind_phys), intent(in) :: dt            ! time step in seconds
 
    integer, intent(in) :: jt(:)         ! Index of cloud top for each column         (ncol)
    integer, intent(in) :: mx(:)         ! Index of cloud top for each column         (ncol)

--- a/zhang_mcfarlane/zm_convr.F90
+++ b/zhang_mcfarlane/zm_convr.F90
@@ -721,7 +721,7 @@ subroutine zm_convr_run(     ncol    ,pver    , &
 
    do i=1,lengath
       if (mumax(i) > 0._kind_phys) then
-         mb(i) = min(mb(i),0.5_kind_phys/(delt*mumax(i)))
+         mb(i) = min(mb(i),1._kind_phys/(delt*mumax(i)))
       else
          mb(i) = 0._kind_phys
       endif
@@ -770,7 +770,7 @@ subroutine zm_convr_run(     ncol    ,pver    , &
 !
 ! q is updated to compute net precip.
 !
-         q(ideep(i),k) = qh(ideep(i),k) + 2._kind_phys*delt*dqdt(i,k)
+         q(ideep(i),k) = qh(ideep(i),k) + delt*dqdt(i,k)
          qtnd(ideep(i),k) = dqdt (i,k)
          cme (ideep(i),k) = cmeg (i,k)
          rprd(ideep(i),k) = rprdg(i,k)
@@ -785,13 +785,13 @@ subroutine zm_convr_run(     ncol    ,pver    , &
 ! Compute precip by integrating change in water vapor minus detrained cloud water
    do k = pver,msg + 1,-1
       do i = 1,ncol
-          prec(i) = prec(i) - dpp(i,k)* (q(i,k)-qh(i,k)) - dpp(i,k)*(dlf(i,k)+dif(i,k))*2._kind_phys*delt
+          prec(i) = prec(i) - dpp(i,k)* (q(i,k)-qh(i,k)) - dpp(i,k)*(dlf(i,k)+dif(i,k))*delt
       end do
    end do
 
 ! obtain final precipitation rate in m/s.
    do i = 1,ncol
-      prec(i) = rgrav*max(prec(i),0._kind_phys)/ (2._kind_phys*delt)/1000._kind_phys
+      prec(i) = rgrav*max(prec(i),0._kind_phys)/ delt/1000._kind_phys
    end do
 
 ! Compute reserved liquid (not yet in cldliq) for energy integrals.


### PR DESCRIPTION
ZM has for a very long time passed in .5*timestep and then inside multiplied by 2 in several places (and also done 0.5/input_timestep in several other locations).  It also hinders CCPP'ization as we do not have a half timestep standard name.  This confusing, unnecessary logic will be removed.

To confirm the results, see this email from @adamrher

Your ZM branch has round-off level differences with cam6_4_018, so it's working as expected (plots attached).
Ignore the top right panel "cam6_4_015" -- that's my clubb+mf branch and something is very wrong with that run.

