### PR TITLE
Add PR templates for atmospheric_physics

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/develop-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/develop-template.md
@@ -12,3 +12,5 @@ List all existing files that have been modified, and describe the changes:
 (Helpful git command: `git diff --name-status development...<your_branch_name>`)
 
 List any test failures:
+
+Is this a science-changing update? New physics package, algorithm change, tuning changes, etc?

--- a/.github/PULL_REQUEST_TEMPLATE/develop-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/develop-template.md
@@ -1,8 +1,8 @@
 Originator(s):
 
-Summary (include the keyword ['closes', 'fixes', 'resolves'] and issue number):
+Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
 
-Describe any changes made to the namelist:
+List all namelist files that were added or changed:
 
 List all files eliminated and why:
 
@@ -13,4 +13,6 @@ List all existing files that have been modified, and describe the changes:
 
 List any test failures:
 
-Is this a science-changing update? New physics package, algorithm change, tuning changes, etc?
+Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?
+
+If yes to the above question, list how this code was validated with the new/modified features?

--- a/.github/PULL_REQUEST_TEMPLATE/develop-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/develop-template.md
@@ -11,8 +11,8 @@ List all files added and what they do:
 List all existing files that have been modified, and describe the changes: 
 (Helpful git command: `git diff --name-status development...<your_branch_name>`)
 
-List any test failures:
+List all automated tests that failed, as well as an explanation for why they weren't fixed:
 
 Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?
 
-If yes to the above question, list how this code was validated with the new/modified features?
+If yes to the above question, describe how this code was validated with the new/modified features:

--- a/.github/PULL_REQUEST_TEMPLATE/develop-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/develop-template.md
@@ -1,0 +1,14 @@
+Originator(s):
+
+Summary (include the keyword ['closes', 'fixes', 'resolves'] and issue number):
+
+Describe any changes made to the namelist:
+
+List all files eliminated and why:
+
+List all files added and what they do:
+
+List all existing files that have been modified, and describe the changes: 
+(Helpful git command: `git diff --name-status development...<your_branch_name>`)
+
+List any test failures:

--- a/.github/PULL_REQUEST_TEMPLATE/main-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/main-template.md
@@ -1,0 +1,6 @@
+Tag name:
+Originator(s):
+
+List all `develop` PR URLs included in this PR and a short description of each:
+
+List all test failures:

--- a/.github/PULL_REQUEST_TEMPLATE/main-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/main-template.md
@@ -1,6 +1,6 @@
 Tag name (The PR title should also include the tag name):
 Originator(s):
 
-List all `develop` PR numbers included in this PR and the title of each:
+List all `development` PR numbers included in this PR and the title of each:
 
-List all test failures:
+List all automated tests that failed, as well as an explanation for why they weren't fixed:

--- a/.github/PULL_REQUEST_TEMPLATE/main-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/main-template.md
@@ -1,6 +1,6 @@
 Tag name (The PR title should also include the tag name):
 Originator(s):
 
-List all `develop` PR URLs included in this PR and a short description of each:
+List all `develop` PR numbers included in this PR and the title of each:
 
 List all test failures:

--- a/.github/PULL_REQUEST_TEMPLATE/main-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/main-template.md
@@ -1,4 +1,4 @@
-Tag name:
+Tag name (The PR title should also include the tag name):
 Originator(s):
 
 List all `develop` PR URLs included in this PR and a short description of each:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 Please go the the `Preview` tab and select the appropriate PR template:
 
-* [Develop branch](?expand=1&template=develop-template.md)
-* [Main branch](?expand=1&template=main-template.md)
+* [development branch](?expand=1&template=develop-template.md)
+* [main branch](?expand=1&template=main-template.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+Please go the the `Preview` tab and select the appropriate PR template:
+
+* [Develop branch](?expand=1&template=develop-template.md)
+* [Main branch](?expand=1&template=main-template.md)


### PR DESCRIPTION
Brings in new PR templates for atmospheric_physics - as there's no easy way to have multiple accessible PR templates in GitHub, this includes a default template that contains links to the PR templates