### PR TITLE
Implement ccpp_const_get_index in to_be_ccppized to avoid circular dependencies

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,32 @@
 ===============================================================
 
+Tag name:
+Originator(s): jimmielin
+Date: October 17, 2024
+One-line Summary: Implement ccpp_const_get_index in to_be_ccppized to avoid circular dependencies
+Github PR URL: https://github.com/ESCOMP/atmospheric_physics/pull/135
+
+This PR fixes the following NCAR/atmospheric_physics Github issues: N/A
+
+    This routine can be shared by CAM-SIMA code (companion PR to be filled) and atmospheric_physics schemes by passing in the CCPP constituents pointer object.
+
+    This loop-based workaround is to avoid a dependency on cam_ccpp_cap which would in turn depend on all schemes creating a circular dependency.
+
+Code reviewed by: cacraigucar, nusbaume
+
+List all existing files that have been added (A), modified (M), or deleted (D),
+and describe the changes:
+
+- Add to_be_ccppized directory and ccpp_const_utils implementing ccpp_const_get_index
+M       doc/ChangeLog
+A       to_be_ccppized/ccpp_const_utils.F90
+
+List and Describe any test failures: N/A
+
+Summarize any changes to answers: none
+
+===============================================================
+
 Tag name: atmos_phys0_05_001
 Originator(s): nusbaume
 Date: October 10, 2024

--- a/to_be_ccppized/ccpp_const_utils.F90
+++ b/to_be_ccppized/ccpp_const_utils.F90
@@ -1,0 +1,50 @@
+! ccpp_const_utils contains utility functions that use
+! the ccpp constituents property pointer.
+! this code was separated out to remove circular dependencies.
+module ccpp_const_utils
+  implicit none
+  private
+
+  public :: ccpp_const_get_idx
+
+contains
+
+  subroutine ccpp_const_get_idx(constituent_props, name, cindex, errmsg, errflg)
+    use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
+
+    ! Input arguments
+    type(ccpp_constituent_prop_ptr_t), pointer, intent(in)  :: constituent_props(:)
+    character(len=*),                           intent(in)  :: name   ! constituent name
+
+    ! Output arguments
+    integer,                                    intent(out) :: cindex ! global constituent index
+    character(len=512),                         intent(out) :: errmsg ! error message
+    integer,                                    intent(out) :: errflg ! error flag
+
+    ! Local variables
+    integer            :: t_cindex
+    character(len=256) :: t_const_name
+
+    errmsg = ''
+    errflg = 0
+
+    cindex = -1
+
+    ! This convoluted loop is brought to you in exchange for avoiding a
+    ! circular dependency on cam_ccpp_cap::cam_const_get_index.
+    const_props_loop: do t_cindex = lbound(constituent_props, 1), ubound(constituent_props, 1)
+       call constituent_props(t_cindex)%standard_name(t_const_name, errflg, errmsg)
+       if (errflg /= 0) then
+          ! Abort subroutine and return with error.
+          return
+       end if
+
+       if (trim(t_const_name) == trim(name)) then
+          cindex = t_cindex
+          exit const_props_loop
+       end if
+    enddo const_props_loop
+
+  end subroutine ccpp_const_get_idx
+
+end module ccpp_const_utils

--- a/to_be_ccppized/ccpp_const_utils.F90
+++ b/to_be_ccppized/ccpp_const_utils.F90
@@ -1,5 +1,5 @@
 ! ccpp_const_utils contains utility functions that use
-! the ccpp constituents property pointer.
+! the ccpp constituent properties pointer.
 ! this code was separated out to remove circular dependencies.
 module ccpp_const_utils
   implicit none


### PR DESCRIPTION
This routine can be shared by CAM-SIMA code (companion PR to be filled) and `atmospheric_physics` schemes by passing in the CCPP constituents pointer object.

This loop-based workaround is to avoid a dependency on `cam_ccpp_cap` which would in turn depend on all schemes creating a circular dependency.