### PR TITLE
Develop-123-tuvx-radiation-grid

### DIFF
--- a/schemes/musica/musica_ccpp.F90
+++ b/schemes/musica/musica_ccpp.F90
@@ -26,14 +26,17 @@ contains
   !> \section arg_table_musica_ccpp_init Argument Table
   !! \htmlinclude musica_ccpp_init.html
   subroutine musica_ccpp_init(vertical_layer_dimension, vertical_interface_dimension, &
-                              errmsg, errcode)
+                              photolysis_wavelength_grid_interfaces, errmsg, errcode)
+    use ccpp_kinds, only : kind_phys
+
     integer,            intent(in)  :: vertical_layer_dimension     ! (count)
     integer,            intent(in)  :: vertical_interface_dimension ! (count)
+    real(kind_phys),    intent(in)  :: photolysis_wavelength_grid_interfaces(:) ! m
     character(len=512), intent(out) :: errmsg
     integer,            intent(out) :: errcode
 
     call tuvx_init(vertical_layer_dimension, vertical_interface_dimension, &
-                   errmsg, errcode)
+                   photolysis_wavelength_grid_interfaces, errmsg, errcode)
     if (errcode /= 0) return
     call micm_init(errmsg, errcode)
     if (errcode /= 0) return

--- a/schemes/musica/musica_ccpp.meta
+++ b/schemes/musica/musica_ccpp.meta
@@ -19,6 +19,12 @@
   type = integer
   dimensions = ()
   intent = in
+[ photolysis_wavelength_grid_interfaces ]
+  standard_name = photolysis_wavelength_grid_interfaces
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (photolysis_wavelength_grid_interface_dimension)
+  intent = in
 [ errmsg ]
   standard_name = ccpp_error_message
   units = none

--- a/schemes/musica/tuvx/musica_ccpp_tuvx_wavelength_grid.F90
+++ b/schemes/musica/tuvx/musica_ccpp_tuvx_wavelength_grid.F90
@@ -5,6 +5,17 @@ module musica_ccpp_tuvx_wavelength_grid
   private
   public :: create_wavelength_grid
 
+  ! TUV-x Wavelegnth grid notes
+  !
+  !-----------------------------------------------------------------------
+  ! The wavelength grid used with TUV-x is based on the grid used in the
+  ! CAM-Chem photolysis rate constant lookup tables. Slight modifications
+  ! were made to the grid in the Shumann-Runge and Lyman-alpha regions to
+  ! work with the expectations of the TUV-x code.
+  !
+  ! The wavelength grid is defined by the host model. Any wavelength-
+  ! resolved quantities passed to TUV-x must be on this grid.
+
   !> Label for height grid in TUV-x
   character(len=*), parameter, public :: wavelength_grid_label = "wavelength"
   !> Units for height grid in TUV-x
@@ -13,23 +24,35 @@ module musica_ccpp_tuvx_wavelength_grid
 contains
 
   !> Creates a TUV-x wavelength grid
-  function create_wavelength_grid( num_wavelength_bin, errmsg, errcode ) &
+  function create_wavelength_grid( wavelength_grid_interfaces, errmsg, errcode ) &
       result( wavelength_grid )
 
+    use ccpp_kinds,       only: kind_phys
     use musica_ccpp_util, only: has_error_occurred
+    use musica_config,    only: config_t
     use musica_tuvx_grid, only: grid_t
     use musica_util,      only: error_t
 
-    integer,          intent(in)  :: num_wavelength_bin
+    real(kind_phys),  intent(in)  :: wavelength_grid_interfaces(:) ! m
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errcode
     type(grid_t),     pointer     :: wavelength_grid
 
-    ! local variable
+    ! local variables
+    real(kind_phys) :: interfaces( size( wavelength_grid_interfaces ) )    ! [nm]
+    reaL(kind_phys) :: midpoints( size( wavelength_grid_interfaces ) - 1 ) ! [nm]
     type(error_t) :: error
 
+    interfaces(:) = wavelength_grid_interfaces(:) * 1.0e9
+    midpoints(:) = &
+        0.5 * ( interfaces( 1: size( interfaces ) - 1 ) &
+                + interfaces( 2: size( interfaces ) ) )
     wavelength_grid => grid_t( wavelength_grid_label, wavelength_grid_unit, &
-                               num_wavelength_bin, error )
+                               size( midpoints ), error )
+    if ( has_error_occurred( error, errmsg, errcode ) ) return
+    call wavelength_grid%set_edges( interfaces, error )
+    if ( has_error_occurred( error, errmsg, errcode ) ) return
+    call wavelength_grid%set_midpoints( midpoints, error )
     if ( has_error_occurred( error, errmsg, errcode ) ) return
 
   end function create_wavelength_grid

--- a/test/musica/test_musica_api.F90
+++ b/test/musica/test_musica_api.F90
@@ -21,10 +21,12 @@ contains
     integer, parameter                                             :: NUM_SPECIES = 4
     integer, parameter                                             :: NUM_COLUMNS = 2
     integer, parameter                                             :: NUM_LAYERS = 2
+    integer, parameter                                             :: NUM_WAVELENGTH_BINS = 102
     integer                                                        :: solver_type
     integer                                                        :: errcode
     character(len=512)                                             :: errmsg
     real(kind_phys)                                                :: time_step                                    ! s
+    real(kind_phys), dimension(NUM_WAVELENGTH_BINS+1)              :: photolysis_wavelength_grid_interfaces        ! m
     real(kind_phys), dimension(NUM_COLUMNS,NUM_LAYERS)             :: geopotential_height_wrt_surface_at_midpoint  ! m
     real(kind_phys), dimension(NUM_COLUMNS,NUM_LAYERS+1)           :: geopotential_height_wrt_surface_at_interface ! m
     real(kind_phys), dimension(NUM_COLUMNS)                        :: surface_geopotential                         ! m2 s-2
@@ -47,6 +49,116 @@ contains
     solver_type = Rosenbrock
     num_grid_cells = NUM_COLUMNS * NUM_LAYERS
     time_step = 60._kind_phys
+    ! These are the values that will be used in CAM-SIMA and correspond to the wavelength
+    ! bins used in the CAM-Chem photolysis rate constant lookup table.
+    !
+    ! We're using the actual values here because several of the TS1/TSMLT photolysis
+    ! rate constant configurations are sensitive to the wavelength grid.
+    photolysis_wavelength_grid_interfaces = (/ &
+      120.0e-9_kind_phys, &
+      121.4e-9_kind_phys, &
+      121.9e-9_kind_phys, &
+      123.5e-9_kind_phys, &
+      124.3e-9_kind_phys, &
+      125.5e-9_kind_phys, &
+      126.3e-9_kind_phys, &
+      127.1e-9_kind_phys, &
+      130.1e-9_kind_phys, &
+      131.1e-9_kind_phys, &
+      135.0e-9_kind_phys, &
+      140.0e-9_kind_phys, &
+      145.0e-9_kind_phys, &
+      150.0e-9_kind_phys, &
+      155.0e-9_kind_phys, &
+      160.0e-9_kind_phys, &
+      165.0e-9_kind_phys, &
+      168.0e-9_kind_phys, &
+      171.0e-9_kind_phys, &
+      173.0e-9_kind_phys, &
+      174.4e-9_kind_phys, &
+      175.4e-9_kind_phys, &
+      177.0e-9_kind_phys, &
+      178.6e-9_kind_phys, &
+      180.2e-9_kind_phys, &
+      181.8e-9_kind_phys, &
+      183.5e-9_kind_phys, &
+      185.2e-9_kind_phys, &
+      186.9e-9_kind_phys, &
+      188.7e-9_kind_phys, &
+      190.5e-9_kind_phys, &
+      192.3e-9_kind_phys, &
+      194.2e-9_kind_phys, &
+      196.1e-9_kind_phys, &
+      198.0e-9_kind_phys, &
+      200.0e-9_kind_phys, &
+      202.0e-9_kind_phys, &
+      204.1e-9_kind_phys, &
+      206.2e-9_kind_phys, &
+      208.0e-9_kind_phys, &
+      211.0e-9_kind_phys, &
+      214.0e-9_kind_phys, &
+      217.0e-9_kind_phys, &
+      220.0e-9_kind_phys, &
+      223.0e-9_kind_phys, &
+      226.0e-9_kind_phys, &
+      229.0e-9_kind_phys, &
+      232.0e-9_kind_phys, &
+      235.0e-9_kind_phys, &
+      238.0e-9_kind_phys, &
+      241.0e-9_kind_phys, &
+      244.0e-9_kind_phys, &
+      247.0e-9_kind_phys, &
+      250.0e-9_kind_phys, &
+      253.0e-9_kind_phys, &
+      256.0e-9_kind_phys, &
+      259.0e-9_kind_phys, &
+      263.0e-9_kind_phys, &
+      267.0e-9_kind_phys, &
+      271.0e-9_kind_phys, &
+      275.0e-9_kind_phys, &
+      279.0e-9_kind_phys, &
+      283.0e-9_kind_phys, &
+      287.0e-9_kind_phys, &
+      291.0e-9_kind_phys, &
+      295.0e-9_kind_phys, &
+      298.5e-9_kind_phys, &
+      302.5e-9_kind_phys, &
+      305.5e-9_kind_phys, &
+      308.5e-9_kind_phys, &
+      311.5e-9_kind_phys, &
+      314.5e-9_kind_phys, &
+      317.5e-9_kind_phys, &
+      322.5e-9_kind_phys, &
+      327.5e-9_kind_phys, &
+      332.5e-9_kind_phys, &
+      337.5e-9_kind_phys, &
+      342.5e-9_kind_phys, &
+      347.5e-9_kind_phys, &
+      350.0e-9_kind_phys, &
+      355.0e-9_kind_phys, &
+      360.0e-9_kind_phys, &
+      365.0e-9_kind_phys, &
+      370.0e-9_kind_phys, &
+      375.0e-9_kind_phys, &
+      380.0e-9_kind_phys, &
+      385.0e-9_kind_phys, &
+      390.0e-9_kind_phys, &
+      395.0e-9_kind_phys, &
+      400.0e-9_kind_phys, &
+      405.0e-9_kind_phys, &
+      410.0e-9_kind_phys, &
+      415.0e-9_kind_phys, &
+      420.0e-9_kind_phys, &
+      430.0e-9_kind_phys, &
+      440.0e-9_kind_phys, &
+      450.0e-9_kind_phys, &
+      500.0e-9_kind_phys, &
+      550.0e-9_kind_phys, &
+      600.0e-9_kind_phys, &
+      650.0e-9_kind_phys, &
+      700.0e-9_kind_phys, &
+      750.0e-9_kind_phys &
+    /)
     geopotential_height_wrt_surface_at_midpoint(1,:) = (/ 2000.0_kind_phys, 500.0_kind_phys /)
     geopotential_height_wrt_surface_at_midpoint(2,:) = (/ 2000.0_kind_phys, -500.0_kind_phys /)
     geopotential_height_wrt_surface_at_interface(1,:) = (/ 3000.0_kind_phys, 1000.0_kind_phys, 0.0_kind_phys /)
@@ -96,7 +208,8 @@ contains
       call constituent_props_ptr(i)%set(const_prop, errcode, errmsg)
     end do
 
-    call musica_ccpp_init(NUM_LAYERS, NUM_LAYERS+1, errmsg, errcode)
+    call musica_ccpp_init(NUM_LAYERS, NUM_LAYERS+1, photolysis_wavelength_grid_interfaces, &
+                          errmsg, errcode)
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3

--- a/test/musica/tuvx/CMakeLists.txt
+++ b/test/musica/tuvx/CMakeLists.txt
@@ -26,6 +26,34 @@ add_test(
 
 add_memory_check_test(test_tuvx_height_grid $<TARGET_FILE:test_tuvx_height_grid> "" ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
+# Wavelength grid
+add_executable(test_tuvx_wavelength_grid test_tuvx_wavelength_grid.F90)
+
+target_sources(test_tuvx_wavelength_grid
+  PUBLIC
+    ${MUSICA_SRC_PATH}/tuvx/musica_ccpp_tuvx_wavelength_grid.F90
+    ${MUSICA_SRC_PATH}/musica_ccpp_util.F90
+    ${CCPP_TEST_SRC_PATH}/ccpp_kinds.F90
+)
+
+target_link_libraries(test_tuvx_wavelength_grid
+  PRIVATE
+    musica::musica-fortran
+)
+
+set_target_properties(test_tuvx_wavelength_grid
+  PROPERTIES
+  LINKER_LANGUAGE Fortran
+)
+
+add_test(
+  NAME test_tuvx_wavelength_grid
+  COMMAND $<TARGET_FILE:test_tuvx_wavelength_grid>
+  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
+
+add_memory_check_test(test_tuvx_wavelength_grid $<TARGET_FILE:test_tuvx_wavelength_grid> "" ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
 # Temperature
 add_executable(test_tuvx_temperature test_tuvx_temperature.F90)
 

--- a/test/musica/tuvx/configs/ts1_tsmlt.json
+++ b/test/musica/tuvx/configs/ts1_tsmlt.json
@@ -5,12 +5,6 @@
    },
    "grids": [
       {
-         "name": "wavelength",
-         "type": "from csv file",
-         "units": "nm",
-         "file path": "data/grids/wavelength/cam.csv"
-      },
-      {
          "name": "time",
          "type": "from config file",
          "units": "hours",

--- a/test/musica/tuvx/test_tuvx_surface_albedo.F90
+++ b/test/musica/tuvx/test_tuvx_surface_albedo.F90
@@ -22,6 +22,8 @@ contains
     type(grid_t),    pointer :: wavelength_grid
     type(profile_t), pointer :: profile
     real(kind_phys), target  :: host_surface_albedo = 500.5_kind_phys
+    real(kind_phys)          :: wavelength_grid_interfaces(NUM_WAVELENGTH_BIN + 1) = &
+        [200.0e-9_kind_phys, 210.0e-9_kind_phys, 240.0e-9_kind_phys, 300.0e-9_kind_phys, 400.0e-9_kind_phys]
     real(kind_phys)          :: surface_albedos(NUM_WAVELENGTH_BIN + 1)
     character(len=512)       :: errmsg
     integer                  :: errcode
@@ -29,7 +31,7 @@ contains
     real(kind_phys)          :: abs_error = 1e-4
     integer                  :: i
 
-    wavelength_grid => create_wavelength_grid(NUM_WAVELENGTH_BIN, errmsg, errcode)
+    wavelength_grid => create_wavelength_grid(wavelength_grid_interfaces, errmsg, errcode)
     profile => create_surface_albedo_profile( wavelength_grid, errmsg, errcode )
     ASSERT(errcode == 0)
     ASSERT(associated(profile))

--- a/test/musica/tuvx/test_tuvx_wavelength_grid.F90
+++ b/test/musica/tuvx/test_tuvx_wavelength_grid.F90
@@ -1,0 +1,53 @@
+program test_tuvx_wavelength_grid
+
+  use musica_ccpp_tuvx_wavelength_grid
+
+  implicit none
+
+#define ASSERT(x) if (.not.(x)) then; write(*,*) "Assertion failed[", __FILE__, ":", __LINE__, "]: x"; stop 1; endif
+#define ASSERT_NEAR( a, b, abs_error ) if( (abs(a - b) >= abs_error) .and. (abs(a - b) /= 0.0) ) then; write(*,*) "Assertion failed[", __FILE__, ":", __LINE__, "]: a, b"; stop 1; endif
+
+  call test_create_wavelength_grid()
+
+contains
+
+  subroutine test_create_wavelength_grid()
+    use musica_util,      only: error_t
+    use musica_tuvx_grid, only: grid_t
+    use ccpp_kinds,       only: kind_phys
+
+    integer, parameter      :: NUM_WAVELENGTH_GRID_MIDPOINTS = 2
+    integer, parameter      :: NUM_WAVELENGTH_GRID_INTERFACES = 3
+    real(kind_phys), target :: host_interfaces(NUM_WAVELENGTH_GRID_INTERFACES) = [180.0e-9_kind_phys, 200.0e-9_kind_phys, 240.0e-9_kind_phys]
+    real(kind_phys), target :: expected_interfaces(NUM_WAVELENGTH_GRID_INTERFACES) = [180.0_kind_phys, 200.0_kind_phys, 240.0_kind_phys]
+    real(kind_phys), target :: expected_midpoints(NUM_WAVELENGTH_GRID_MIDPOINTS) = [190.0_kind_phys, 220.0_kind_phys]
+    real(kind_phys)         :: interfaces(NUM_WAVELENGTH_GRID_INTERFACES)
+    real(kind_phys)         :: midpoints(NUM_WAVELENGTH_GRID_MIDPOINTS)
+    type(grid_t), pointer   :: wavelength_grid => null()
+    character(len=512)      :: errmsg
+    integer                 :: errcode
+    real(kind_phys)         :: abs_error = 1e-5
+    integer                 :: i
+    type(error_t)           :: error
+
+    wavelength_grid => create_wavelength_grid(host_interfaces, errmsg, errcode)
+    ASSERT(errcode == 0)
+    ASSERT(associated(wavelength_grid))
+
+    call wavelength_grid%get_edges(interfaces, error)
+    ASSERT(error%is_success())
+    do i = 1, NUM_WAVELENGTH_GRID_INTERFACES
+      ASSERT_NEAR(interfaces(i), expected_interfaces(i), abs_error)
+    end do
+
+    call wavelength_grid%get_midpoints(midpoints, error)
+    ASSERT(error%is_success())
+    do i = 1, NUM_WAVELENGTH_GRID_MIDPOINTS
+      ASSERT_NEAR(midpoints(i), expected_midpoints(i), abs_error)
+    end do
+
+    deallocate(wavelength_grid)
+
+  end subroutine test_create_wavelength_grid
+
+end program test_tuvx_wavelength_grid


### PR DESCRIPTION
Updates TUV-x wrapper, tests, and configuration data to allow setting the wavelength grid from the host model. This implementation assumes that there will be a standard-named variable that defines the edges of the wavelength grid to use for photolysis rate constant calculations that is defined by the host model.

Once this gets merged into `development` #123 can be closed.