### PR TITLE
Replace dynamic constituent routine with register phase

### DIFF
--- a/schemes/musica/musica_ccpp.F90
+++ b/schemes/musica/musica_ccpp.F90
@@ -10,6 +10,8 @@ module musica_ccpp
 
 contains
 
+  !> \section arg_table_musica_ccpp_register Argument Table
+  !! \htmlinclude musica_ccpp_register.html
   subroutine musica_ccpp_register(solver_type, num_grid_cells, constituent_props, errmsg, errcode)
     use ccpp_constituent_prop_mod, only: ccpp_constituent_properties_t
 

--- a/schemes/musica/musica_ccpp.meta
+++ b/schemes/musica/musica_ccpp.meta
@@ -2,8 +2,29 @@
   name = musica_ccpp
   type = scheme
   dependencies = micm/musica_ccpp_micm.F90,micm/musica_ccpp_micm_util.F90,tuvx/musica_ccpp_tuvx.F90,tuvx/musica_ccpp_tuvx_height_grid.F90,musica_ccpp_util.F90
-  dynamic_constituent_routine = musica_ccpp_register
 
+[ccpp-arg-table]
+  name  = musica_ccpp_register
+  type  = scheme
+[ solver_type ]
+  standard_name = micm_solver_type
+  units = none
+  type = integer
+  dimensions = ()
+  intent = in
+[ num_grid_cells ]
+  standard_name = number_of_grid_cells
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
+[ constituent_props ]
+  standard_name = dynamic_constituents_for_musica_ccpp
+  units = none
+  dimensions = (:)
+  allocatable = True
+  type = ccpp_constituent_properties_t
+  intent = out
 [ccpp-arg-table]
   name  = musica_ccpp_init
   type  = scheme
@@ -13,6 +34,20 @@
   type = integer
   dimensions = ()
   intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errcode ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+
+[ccpp-arg-table]
 [ vertical_interface_dimension ]
   standard_name = vertical_interface_dimension
   units = none

--- a/schemes/musica/musica_ccpp.meta
+++ b/schemes/musica/musica_ccpp.meta
@@ -25,6 +25,19 @@
   allocatable = True
   type = ccpp_constituent_properties_t
   intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errcode ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+
 [ccpp-arg-table]
   name  = musica_ccpp_init
   type  = scheme

--- a/schemes/musica/musica_ccpp.meta
+++ b/schemes/musica/musica_ccpp.meta
@@ -34,20 +34,6 @@
   type = integer
   dimensions = ()
   intent = in
-[ errmsg ]
-  standard_name = ccpp_error_message
-  units = none
-  type = character | kind = len=512
-  dimensions = ()
-  intent = out
-[ errcode ]
-  standard_name = ccpp_error_code
-  units = 1
-  type = integer
-  dimensions = ()
-  intent = out
-
-[ccpp-arg-table]
 [ vertical_interface_dimension ]
   standard_name = vertical_interface_dimension
   units = none


### PR DESCRIPTION
Originator(s): peverwhee

Summary (include the keyword ['closes', 'fixes', 'resolves'] and issue number): Modifies existing dynamic constituent handling for the MUSICA interface to use the new register phase

Describe any changes made to the namelist: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes:
(Helpful git command: git diff --name-status development...<your_branch_name>)

M schemes/musica/musica_ccpp.F90
M schemes/musica/muscia_ccpp.meta

- remove dynamic_constituent_routine from metadata
- add necessary comment header to Fortran
- add metadata for register routine

List any test failures:

Is this a science-changing update? New physics package, algorithm change, tuning changes, etc? No