### PR TITLE
Fill in errmsg, errflg in check_energy schemes

### DIFF
--- a/schemes/check_energy/check_energy_chng.F90
+++ b/schemes/check_energy/check_energy_chng.F90
@@ -89,6 +89,9 @@ contains
     character(len=512), intent(out)   :: errmsg         ! error message
     integer,            intent(out)   :: errflg         ! error flag
 
+    errmsg = ''
+    errflg = 0
+
     !------------------------------------------------
     ! Physics total energy.
     !------------------------------------------------
@@ -275,6 +278,9 @@ contains
     real(kind_phys) :: ice(ncol)                        ! column integrated ice         (kg/m2)
 
     integer :: i
+
+    errmsg = ''
+    errflg = 0
 
     !------------------------------------------------
     ! Physics total energy.

--- a/schemes/check_energy/check_energy_fix.F90
+++ b/schemes/check_energy/check_energy_fix.F90
@@ -11,7 +11,7 @@ contains
   ! Add heating rate required for global mean total energy conservation
 !> \section arg_table_check_energy_fix_run Argument Table
 !! \htmlinclude arg_table_check_energy_fix_run.html
-  subroutine check_energy_fix_run(ncol, pver, pint, gravit, heat_glob, ptend_s, eshflx, scheme_name)
+  subroutine check_energy_fix_run(ncol, pver, pint, gravit, heat_glob, ptend_s, eshflx, scheme_name, errmsg, errflg)
     ! Input arguments
     integer,            intent(in)    :: ncol           ! number of atmospheric columns
     integer,            intent(in)    :: pver           ! number of vertical layers
@@ -22,10 +22,16 @@ contains
     real(kind_phys),    intent(out)   :: eshflx(:)      ! effective sensible heat flux [W m-2]
                                                         ! for check_energy_chng
 
+    ! Output arguments
     character(len=64),  intent(out)   :: scheme_name    ! scheme name
+    character(len=512), intent(out)   :: errmsg         ! error message
+    integer,            intent(out)   :: errflg         ! error flag
 
     ! Local variables
     integer :: i
+
+    errmsg = ''
+    errflg = 0
 
     ! Set scheme name for check_energy_chng
     scheme_name = "check_energy_fix"

--- a/schemes/check_energy/check_energy_fix.meta
+++ b/schemes/check_energy/check_energy_fix.meta
@@ -53,3 +53,15 @@
   type = character | kind = len=64
   dimensions = ()
   intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/check_energy/check_energy_gmean/check_energy_gmean.F90
+++ b/schemes/check_energy/check_energy_gmean/check_energy_gmean.F90
@@ -19,7 +19,8 @@ contains
        pint, &
        te_ini_dyn, teout, &
        tedif_glob, heat_glob, &
-       teinp_glob, teout_glob, psurf_glob, ptopb_glob)
+       teinp_glob, teout_glob, psurf_glob, ptopb_glob, &
+       errmsg, errflg)
 
     ! This scheme is non-portable due to dependency: Global mean module gmean from src/utils
     use gmean_mod, only: gmean
@@ -43,9 +44,15 @@ contains
     real(kind_phys),    intent(out)   :: psurf_glob     ! global mean surface pressure [Pa]
     real(kind_phys),    intent(out)   :: ptopb_glob     ! global mean top boundary pressure [Pa]
 
+    character(len=512), intent(out)   :: errmsg         ! error message
+    integer,            intent(out)   :: errflg         ! error flag
+
     ! Local variables
     real(kind_phys) :: te(ncol, 4)                      ! total energy of input/output states (copy)
     real(kind_phys) :: te_glob(4)                       ! global means of total energy
+
+    errmsg = ''
+    errflg = 0
 
     ! Copy total energy out of input and output states.
     ! These four fields will have their global means calculated respectively

--- a/schemes/check_energy/check_energy_gmean/check_energy_gmean.meta
+++ b/schemes/check_energy/check_energy_gmean/check_energy_gmean.meta
@@ -84,3 +84,15 @@
   type = real | kind = kind_phys
   dimensions = ()
   intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/check_energy/check_energy_save_teout.F90
+++ b/schemes/check_energy/check_energy_save_teout.F90
@@ -13,7 +13,7 @@ contains
 
 !> \section arg_table_check_energy_save_teout_run Argument Table
 !! \htmlinclude arg_table_check_energy_save_teout_run.html
-  subroutine check_energy_save_teout_run(ncol, te_cur_dyn, teout)
+  subroutine check_energy_save_teout_run(ncol, te_cur_dyn, teout, errmsg, errflg)
 
     ! Input arguments
     integer,            intent(in)    :: ncol           ! number of atmospheric columns
@@ -21,6 +21,11 @@ contains
 
     ! Output arguments
     real(kind_phys),    intent(out)   :: teout(:)       ! total energy for global fixer in next timestep [J m-2]
+    character(len=512), intent(out)   :: errmsg         ! error message
+    integer,            intent(out)   :: errflg         ! error flag
+
+    errmsg = ''
+    errflg = 0
 
     ! nb hplin: note that in physpkg.F90, the pbuf is updated to the previous dyn timestep
     ! through itim_old. Need to check if we need to replicate such pbuf functionality

--- a/schemes/check_energy/check_energy_save_teout.meta
+++ b/schemes/check_energy/check_energy_save_teout.meta
@@ -23,3 +23,15 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
   intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/check_energy/check_energy_zero_fluxes.F90
+++ b/schemes/check_energy/check_energy_zero_fluxes.F90
@@ -12,7 +12,7 @@ contains
 
 !> \section arg_table_check_energy_zero_fluxes_run Argument Table
 !! \htmlinclude arg_table_check_energy_zero_fluxes_run.html
-  subroutine check_energy_zero_fluxes_run(ncol, name, flx_vap, flx_cnd, flx_ice, flx_sen)
+  subroutine check_energy_zero_fluxes_run(ncol, name, flx_vap, flx_cnd, flx_ice, flx_sen, errmsg, errflg)
     ! Input arguments
     integer,            intent(in)     :: ncol           ! number of atmospheric columns
 
@@ -22,6 +22,11 @@ contains
     real(kind_phys),    intent(out)    :: flx_cnd(:)     ! boundary flux of liquid+ice (precip?) [m s-1]
     real(kind_phys),    intent(out)    :: flx_ice(:)     ! boundary flux of ice (snow?) [m s-1]
     real(kind_phys),    intent(out)    :: flx_sen(:)     ! boundary flux of sensible heat [W m-2]
+    character(len=512), intent(out)    :: errmsg         ! error message
+    integer,            intent(out)    :: errflg         ! error flag
+
+    errmsg = ''
+    errflg = 0
 
     ! reset values to zero
     name = ''

--- a/schemes/check_energy/check_energy_zero_fluxes.meta
+++ b/schemes/check_energy/check_energy_zero_fluxes.meta
@@ -41,3 +41,15 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
   intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/check_energy/dycore_energy_consistency_adjust.F90
+++ b/schemes/check_energy/dycore_energy_consistency_adjust.F90
@@ -16,7 +16,8 @@ contains
       do_consistency_adjust, &
       scaling_dycore, &
       tend_dTdt, &
-      tend_dTdt_local)
+      tend_dTdt_local, &
+      errmsg, errflg)
 
     ! Input arguments
     integer,            intent(in)    :: ncol                  ! number of atmospheric columns
@@ -26,7 +27,12 @@ contains
     real(kind_phys),    intent(in)    :: tend_dTdt(:,:)        ! model physics temperature tendency [K s-1]
 
     ! Output arguments
-    real(kind_phys),    intent(out) :: tend_dTdt_local(:,:)  ! (scheme) temperature tendency [K s-1]
+    real(kind_phys),    intent(out)   :: tend_dTdt_local(:,:)  ! (scheme) temperature tendency [K s-1]
+    character(len=512), intent(out)   :: errmsg                ! error message
+    integer,            intent(out)   :: errflg                ! error flag
+
+    errmsg = ''
+    errflg = 0
 
     if (do_consistency_adjust) then
       ! original formula for scaling of temperature:

--- a/schemes/check_energy/dycore_energy_consistency_adjust.meta
+++ b/schemes/check_energy/dycore_energy_consistency_adjust.meta
@@ -41,3 +41,15 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out


### PR DESCRIPTION
Originator(s): @jimmielin 

Summary (include the keyword ['closes', 'fixes', 'resolves'] and issue number):

Fixes #159. b4b changes to include errmsg, errflg in the check_energy schemes

Describe any changes made to the namelist: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
Add errmsg, errflg (or set when not previously set) in check_energy schemes.

M       schemes/check_energy/check_energy_chng.F90
M       schemes/check_energy/check_energy_fix.F90
M       schemes/check_energy/check_energy_fix.meta
M       schemes/check_energy/check_energy_gmean/check_energy_gmean.F90
M       schemes/check_energy/check_energy_gmean/check_energy_gmean.meta
M       schemes/check_energy/check_energy_save_teout.F90
M       schemes/check_energy/check_energy_save_teout.meta
M       schemes/check_energy/check_energy_zero_fluxes.F90
M       schemes/check_energy/check_energy_zero_fluxes.meta
M       schemes/check_energy/dycore_energy_consistency_adjust.F90
M       schemes/check_energy/dycore_energy_consistency_adjust.meta
```

List any test failures: N/A

Is this a science-changing update? New physics package, algorithm change, tuning changes, etc? No