### PR TITLE
don't set water species property for species that air_composition handles

### DIFF
--- a/test/test_schemes/initialize_constituents.F90
+++ b/test/test_schemes/initialize_constituents.F90
@@ -119,7 +119,6 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
              vertical_dim = 'vertical_layer_dimension', &
              min_value = 0.0_kind_phys,                 &
              advected = .true.,                         &
-             water_species = .true.,                    &
              mixing_ratio_type = 'wet',                 &
              errcode = errcode,                         &
              errmsg = errmsg)

--- a/test/test_schemes/initialize_constituents.F90
+++ b/test/test_schemes/initialize_constituents.F90
@@ -112,6 +112,9 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
              errcode = errcode,                         &
              errmsg = errmsg)
        else if (any(water_species_std_names == trim(constituent_names(var_index)))) then
+          ! Do not set water_species = .true. for water species mixing ratios
+          !   Avoiding mismatch in properties vs. metadata-specified constituents
+          !   Water species properties are set in air_composition.F90 in CAM-SIMA
           call constituents(var_index)%instantiate(     &
              std_name = constituent_names(var_index),   &
              long_name = constituent_names(var_index),  &


### PR DESCRIPTION
Originator(s): peverwhee

Summary (include the keyword ['closes', 'fixes', 'resolves'] and issue number):
Removes water_species property from instantiate call for water vapor mixing ratio species (as air_composition will set those). We may run into this issue again at some point for the water vapor number concentration variables, but hopefully by then we'll have metadata properties for setting that!
can supersede https://github.com/ESCOMP/CAM-SIMA/pull/342

Describe any changes made to the namelist: n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M   test/test_schemes/initialize_constituents.F90
- remove water_species property from instantiate call

List any test failures: all expected tests pass

Is this a science-changing update? New physics package, algorithm change, tuning changes, etc? no
