### PR TITLE
Use new constituent tendency updater in cam7 SDF

### DIFF
--- a/suites/suite_cam7.xml
+++ b/suites/suite_cam7.xml
@@ -19,7 +19,7 @@
 
     <!-- Dry Adiabatic Adjustment -->
     <scheme>dadadj</scheme>
-    <scheme>dadadj_apply_qv_tendency</scheme>
+    <scheme>apply_constituent_tendencies</scheme>
     <scheme>apply_heating_rate</scheme>
     <scheme>qneg</scheme>
     <scheme>geopotential_temp</scheme>


### PR DESCRIPTION
Originator(s): peverwhee

Summary (include the keyword ['closes', 'fixes', 'resolves'] and issue number):

Uses new constituent tendency updater scheme (apply_constituent_tendencies) instead of the temporary dry adiabatic adjustment updater (that no longer exists!)

closes #179 

Describe any changes made to the namelist: N/A

List all files eliminated and why: N/A

List all files added and what they do:

List all existing files that have been modified, and describe the changes:
(Helpful git command: git diff --name-status development...<your_branch_name>)

M suites/suite_cam7.xml
- use apply_constituent_tendencies scheme

List any test failures: n/a

Is this a science-changing update? New physics package, algorithm change, tuning changes, etc? No