### PR TITLE
update instantaneous history flag to be 'inst' instead of 'lst'

### DIFF
--- a/schemes/sima_diagnostics/sima_state_diagnostics.F90
+++ b/schemes/sima_diagnostics/sima_state_diagnostics.F90
@@ -56,7 +56,7 @@ CONTAINS
       ! Add state fields
       call history_add_field('PS',        'surface_pressure',                                              horiz_only,  'avg', 'Pa')
       call history_add_field('PSDRY',     'surface_pressure_of_dry_air',                                   horiz_only,  'avg', 'Pa')
-      call history_add_field('PHIS',      'surface_geopotential',                                          horiz_only,  'lst', 'Pa')
+      call history_add_field('PHIS',      'surface_geopotential',                                          horiz_only, 'inst', 'Pa')
       call history_add_field('T',         'air_temperature',                                                    'lev',  'avg', 'K')
       call history_add_field('U',         'eastward_wind',                                                      'lev',  'avg', 'm s-1')
       call history_add_field('V',         'northward_wind',                                                     'lev',  'avg', 'm s-1')


### PR DESCRIPTION
Originator(s): peverwhee

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
Changing (currently unused) instantaneous flag from 'lst' to 'inst'
related to https://github.com/ESCOMP/CAM-SIMA/issues/372

List all namelist files that were added or changed: n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M   schemes/sima_diagnostics/sima_state_diagnostics.F90
- change 'lst' to 'inst'

List all automated tests that failed, as well as an explanation for why they weren't fixed: n/a

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? no

If yes to the above question, describe how this code was validated with the new/modified features:
