### PR TITLE
Fix broken dme_adjust tests

### DIFF
--- a/schemes/conservation_adjust/check_energy/check_energy_chng.meta
+++ b/schemes/conservation_adjust/check_energy/check_energy_chng.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = check_energy_chng
   type = scheme
-  dependencies = ../../../../data/cam_thermo.F90,../../../../data/cam_thermo_formula.F90
+  dependencies = ../../../../../data/cam_thermo.F90,../../../../../data/cam_thermo_formula.F90
 
 
 [ccpp-arg-table]

--- a/schemes/conservation_adjust/check_energy/check_energy_gmean/check_energy_gmean.meta
+++ b/schemes/conservation_adjust/check_energy/check_energy_gmean/check_energy_gmean.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = check_energy_gmean
   type = scheme
-  dependencies = ../../../../../utils/gmean_mod.F90
+  dependencies = ../../../../../../utils/gmean_mod.F90
 
 [ccpp-arg-table]
   name  = check_energy_gmean_run

--- a/suites/suite_cam4.xml
+++ b/suites/suite_cam4.xml
@@ -155,7 +155,9 @@
     <scheme>check_energy_save_teout</scheme>
 
     <!-- Dry Mass and Energy adjust -->
-    <scheme>dme_adjust</scheme>
+    <!-- COMMENTED OUT until qini/liqini/iceini have initialization routines -->
+    <!-- See https://github.com/ESCOMP/atmospheric_physics/issues/222 -->
+    <!-- <scheme>dme_adjust</scheme> -->
 
     <!-- MPAS and SE specific scaling of temperature for enforcing energy consistency:
          First, calculate the scaling based off cp_or_cv_dycore (from cam_thermo_water_update)

--- a/suites/suite_cam7.xml
+++ b/suites/suite_cam7.xml
@@ -93,7 +93,9 @@
     <scheme>thermo_water_update</scheme>
 
     <!-- Dry Mass and Energy adjust -->
-    <scheme>dme_adjust</scheme>
+    <!-- COMMENTED OUT until qini/liqini/iceini have initialization routines -->
+    <!-- See https://github.com/ESCOMP/atmospheric_physics/issues/222 -->
+    <!-- <scheme>dme_adjust</scheme> -->
 
     <!-- MPAS and SE specific scaling of temperature for enforcing energy consistency:
          First, calculate the scaling based off cp_or_cv_dycore (from cam_thermo_water_update)

--- a/suites/suite_kessler.xml
+++ b/suites/suite_kessler.xml
@@ -35,6 +35,7 @@
     <scheme>thermo_water_update</scheme>
 
     <!-- COMMENTED OUT until qini/liqini/iceini have initialization routines -->
+    <!-- See https://github.com/ESCOMP/atmospheric_physics/issues/222 -->
     <!-- <scheme>dme_adjust</scheme> -->
 
     <!-- MPAS and SE specific scaling of temperature for enforcing energy consistency:

--- a/suites/suite_tj2016.xml
+++ b/suites/suite_tj2016.xml
@@ -25,8 +25,10 @@
     <scheme>qneg</scheme>
 
     <!-- Update cp/cv for energy computation based in updated water variables -->
+    <scheme>thermo_water_update</scheme>
 
     <!-- COMMENTED OUT until qini/liqini/iceini have initialization routines -->
+    <!-- See https://github.com/ESCOMP/atmospheric_physics/issues/222 -->
     <!-- <scheme>dme_adjust</scheme> -->
 
     <!-- MPAS and SE specific scaling of temperature for enforcing energy consistency:

--- a/test/test_suites/suite_dme_adjust.xml
+++ b/test/test_suites/suite_dme_adjust.xml
@@ -4,6 +4,7 @@
    <group name="physics_after_coupler">
        <scheme>initialize_constituents</scheme>
        <scheme>dme_adjust</scheme>
+       <scheme>sima_state_diagnostics</scheme>
    </group>
 </suite>
 


### PR DESCRIPTION
Originator(s):cacraig

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
 - During CAM-SIMA regression testing, a number of issues were discovered.  This PR fixes them   
      - Needed to introduce a regression test for dme_adjust
      - Forgot to comment out dme_adjust in a couple of suites (see #222 ) 
      - Inadvertently removed a scheme from TJ16

List all namelist files that were added or changed: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M       schemes/conservation_adjust/check_energy/check_energy_chng.meta
M       schemes/conservation_adjust/check_energy/check_energy_gmean/check_energy_gmean.meta
             - Change relative location for dependencies due to introduction of a new subdirectory layer
             
M       suites/suite_cam4.xml
M       suites/suite_cam7.xml
M       suites/suite_kessler.xml
M       suites/suite_tj2016.xml
             - comment out and/or augment comment for dme_adjust (see #222)
             
M       test/test_suites/suite_dme_adjust.xml
             - Add diagnostics scheme so there are baselines for dme_adjust

List all automated tests that failed, as well as an explanation for why they weren't fixed: N/A

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? N/A

If yes to the above question, describe how this code was validated with the new/modified features: N/A
