### PR TITLE
fix invalid horizontal dimensions

### DIFF
--- a/schemes/sima_diagnostics/check_energy_fix_diagnostics.meta
+++ b/schemes/sima_diagnostics/check_energy_fix_diagnostics.meta
@@ -25,7 +25,7 @@
   standard_name = vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
   units = J m-2
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   intent = in
 [ te_cur_dyn ]
   standard_name = vertically_integrated_total_energy_using_dycore_energy_formula

--- a/schemes/tropopause_find/tropopause_find.meta
+++ b/schemes/tropopause_find/tropopause_find.meta
@@ -115,7 +115,7 @@
   standard_name = tropopause_air_pressure_from_tropopause_climatology_dataset
   units = Pa
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension, number_of_time_slices_in_tropopause_climatology_dataset)
+  dimensions = (horizontal_loop_extent, number_of_time_slices_in_tropopause_climatology_dataset)
   intent = in
 [ tropp_days ]
   standard_name = tropopause_calendar_days_from_tropopause_climatology


### PR DESCRIPTION
Originator(s): peverwhee

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
The newest framework tag has checking for proper horizontal dimensions (depending on the phase), so this just fixes two instances of the incorrect horizontal dimension being used.

List all namelist files that were added or changed: n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M   schemes/sima_diagnostics/check_energy_fix_diagnostics.meta
M   schemes/tropopause_find/tropopause_find.meta
 - replace horizontal_dimension with horizontal_loop_extent in run phase

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? no

If yes to the above question, describe how this code was validated with the new/modified features:
