### PR TITLE
Make array assignments explicit in coords_1d.F90

### DIFF
--- a/to_be_ccppized/coords_1d.F90
+++ b/to_be_ccppized/coords_1d.F90
@@ -58,12 +58,12 @@ module coords_1d
     
       coords = allocate_coords(size(ifc, 1), size(ifc, 2) - 1)
     
-      coords%ifc = ifc
-      coords%mid = mid
-      coords%del = del
-      coords%dst = dst
-      coords%rdel = rdel
-      coords%rdst = rdst
+      coords%ifc(:,:) = ifc(:,:)
+      coords%mid(:,:) = mid(:,:)
+      coords%del(:,:) = del(:,:)
+      coords%dst(:,:) = dst(:,:)
+      coords%rdel(:,:) = rdel(:,:)
+      coords%rdst(:,:) = rdst(:,:)
     
     end function new_Coords1D_from_fields
     
@@ -75,12 +75,12 @@ module coords_1d
     
       coords = allocate_coords(size(ifc, 1), size(ifc, 2) - 1)
     
-      coords%ifc = ifc
-      coords%mid = 0.5_r8 * (ifc(:,:coords%d)+ifc(:,2:))
-      coords%del = coords%ifc(:,2:) - coords%ifc(:,:coords%d)
-      coords%dst = coords%mid(:,2:) - coords%mid(:,:coords%d-1)
-      coords%rdel = 1._r8/coords%del
-      coords%rdst = 1._r8/coords%dst
+      coords%ifc(:,:) = ifc(:,:)
+      coords%mid(:,:) = 0.5_r8 * (ifc(:,:coords%d)+ifc(:,2:))
+      coords%del(:,:) = coords%ifc(:,2:) - coords%ifc(:,:coords%d)
+      coords%dst(:,:) = coords%mid(:,2:) - coords%mid(:,:coords%d-1)
+      coords%rdel(:,:) = 1._r8/coords%del(:,:)
+      coords%rdst(:,:) = 1._r8/coords%dst(:,:)
     
     end function new_Coords1D_from_int
     
@@ -97,12 +97,12 @@ module coords_1d
     
       section = allocate_coords(n_bnds(2)-n_bnds(1)+1, d_bnds(2)-d_bnds(1)+1)
     
-      section%ifc = self%ifc(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)+1)
-      section%mid = self%mid(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
-      section%del = self%del(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
-      section%dst = self%dst(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)-1)
-      section%rdel = self%rdel(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
-      section%rdst = self%rdst(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)-1)
+      section%ifc(:,:) = self%ifc(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)+1)
+      section%mid(:,:) = self%mid(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
+      section%del(:,:) = self%del(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
+      section%dst(:,:) = self%dst(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)-1)
+      section%rdel(:,:) = self%rdel(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
+      section%rdst(:,:) = self%rdst(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)-1)
     
     end function section
     


### PR DESCRIPTION
Originator(s): @gdicker1, @johnmauff

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Fixes #250. This change ensures that an intermediate allocate isn't used when assigning to arrays with NVHPC v24.9 and newer on Derecho. This unnecessary allocation seems to not be cleaned up well and contributes to an apparent memory leak when using NVHPC compilers with CAM.

List all namelist files that were added or changed: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

M       to_be_ccppized/coords_1d.F90
* Convert statements like coords%ifc = ifc to more explicit array assignment like coords%ifc(:,:) = ifc(:,:).

List all automated tests that failed, as well as an explanation for why they weren't fixed: TBD

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? No

If yes to the above question, describe how this code was validated with the new/modified features: N/A
