### PR TITLE
Fix convect_shallow standard names to match spreadsheet

### DIFF
--- a/doc/NamesNotInDictionary.txt
+++ b/doc/NamesNotInDictionary.txt
@@ -1,165 +1,33 @@
 
 #######################
 Date/time of when script was run:
-2025-07-09 16:37:10.272741
+2025-07-23 11:39:40.836320
 #######################
 
 Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/test/test_schemes/initialize_constituents.meta
+atmospheric_physics/schemes/sima_diagnostics/sima_tend_diagnostics.meta
 
     - ccpp_error_code
     - ccpp_error_message
-    - dynamic_constituents_for_initialize_constituents
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/test/test_schemes/file_io_test.meta
+atmospheric_physics/schemes/sima_diagnostics/cloud_particle_sedimentation_diagnostics.meta
 
     - ccpp_error_code
     - ccpp_error_message
-    - filename_of_rrtmgp_shortwave_coefficients
+    - stratiform_lwe_cloud_ice_surface_flux_due_to_sedimentation
+    - stratiform_rain_flux_at_surface_due_to_sedimentation
+    - tendency_of_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
+    - tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/held_suarez/held_suarez_1994.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - scheme_name
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/hack_shallow/set_general_conv_fluxes_to_shallow.meta
-
-    - frozen_precipitation_flux_at_interface_due_to_convection
-    - frozen_precipitation_flux_at_interface_due_to_shallow_convection
-    - lwe_frozen_precipitation_rate_at_surface_due_to_convection
-    - lwe_frozen_precipitation_rate_at_surface_due_to_shallow_convection
-    - lwe_precipitation_rate_at_surface_due_to_convection
-    - lwe_precipitation_rate_at_surface_due_to_shallow_convection
-    - net_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
-    - precipitation_flux_at_interface_due_to_convection
-    - precipitation_flux_at_interface_due_to_shallow_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_shallow_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_shallow_convection
-    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_convection
-    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/hack_shallow/convect_shallow_sum_to_deep.meta
-
-    - atmosphere_convective_mass_flux_due_to_all_convection
-    - atmosphere_convective_mass_flux_due_to_deep_convection
-    - atmosphere_convective_mass_flux_due_to_shallow_convection
-    - ccpp_error_code
-    - ccpp_error_message
-    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_all_convection
-    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_deep_convection
-    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-    - pressure_at_cloud_base_for_all_convection
-    - pressure_at_cloud_top_for_all_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection_excluding_subcloud_evaporation
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection_excluding_subcloud_evaporation
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection_excluding_subcloud_evaporation
-    - vertical_index_at_cloud_base_for_all_convection
-    - vertical_index_at_cloud_base_for_shallow_convection
-    - vertical_index_at_cloud_top_for_all_convection
-    - vertical_index_at_cloud_top_for_shallow_convection
-    - vertical_index_at_top_of_deep_convection_for_convective_columns
-    - vertical_index_of_deep_convection_launch_level_for_convective_columns
-    - vertically_integrated_cloud_liquid_water_tendency_due_to_all_convection_to_be_applied_later_in_time_loop
-    - vertically_integrated_cloud_liquid_water_tendency_due_to_shallow_convection_to_be_applied_later_in_time_loop
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/hack_shallow/set_shallow_conv_fluxes_to_general.meta
-
-    - lwe_precipitation_rate_at_surface_due_to_convection
-    - lwe_precipitation_rate_at_surface_due_to_shallow_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection_excluding_subcloud_evaporation
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection_excluding_subcloud_evaporation
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/hack_shallow/hack_convect_shallow.meta
-
-    - atmosphere_convective_mass_flux_due_to_shallow_convection
-    - ccpp_constituent_properties
-    - ccpp_constituent_tendencies
-    - ccpp_constituents
-    - ccpp_error_code
-    - ccpp_error_message
-    - characteristic_adjustment_time_for_shallow_convection
-    - convective_water_vapor_wrt_moist_air_and_condensed_water_perturbation_due_to_pbl_eddies
-    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-    - flag_for_cloud_area_fraction_to_use_shallow_convection_calculated_cloud_area_fraction
-    - in_cloud_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-    - liquid_water_static_energy_flux_due_to_shallow_convection
-    - lwe_precipitation_rate_at_surface_due_to_shallow_convection
-    - net_liquid_and_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
-    - number_of_ccpp_constituents
-    - rain_water_autoconversion_coefficient_for_shallow_convection
-    - reference_pressure_at_interface
-    - scheme_name
-    - shallow_convective_cloud_area_fraction_from_shallow_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection_excluding_subcloud_evaporation
-    - total_water_flux_due_to_shallow_convection
-    - vertical_index_at_cloud_base_for_shallow_convection
-    - vertical_index_at_cloud_top_for_shallow_convection
-    - vertical_layer_index_of_cloud_fraction_top
-    - vertically_integrated_cloud_liquid_water_tendency_due_to_shallow_convection_to_be_applied_later_in_time_loop
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/check_energy_fix_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - net_sensible_heat_flux_through_top_and_bottom_of_atmosphere_column
-    - vertically_integrated_total_energy_using_dycore_energy_formula
-    - vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
-    - vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/zm_diagnostics.meta
-
-    - atmosphere_convective_mass_flux_due_to_deep_convection
-    - atmosphere_downdraft_convective_mass_flux_for_deep_convection_for_convective_columns
-    - atmosphere_updraft_convective_mass_flux_for_deep_convection_for_convective_columns
-    - ccpp_error_code
-    - ccpp_error_message
-    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_deep_convection
-    - frozen_precipitation_flux_at_interface_due_to_deep_convection
-    - horizontal_index_of_convective_columns_for_deep_convection_for_convective_columns
-    - in_cloud_eastward_wind_in_downdraft_due_to_deep_convection
-    - in_cloud_eastward_wind_in_updraft_due_to_deep_convection
-    - in_cloud_northward_wind_in_downdraft_due_to_deep_convection
-    - in_cloud_northward_wind_in_updraft_due_to_deep_convection
-    - lwe_precipitation_rate_at_surface_due_to_deep_convection
-    - precipitation_flux_at_interface_due_to_deep_convection
-    - surface_air_pressure
-    - tendency_of_eastward_wind_due_to_zhang_mcfarlane_deep_convective_downdraft_pressure_gradient_term
-    - tendency_of_eastward_wind_due_to_zhang_mcfarlane_deep_convective_updraft_pressure_gradient_term
-    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection
-    - tendency_of_northward_wind_due_to_zhang_mcfarlane_deep_convective_downdraft_pressure_gradient_term
-    - tendency_of_northward_wind_due_to_zhang_mcfarlane_deep_convective_updraft_pressure_gradient_term
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection
-    - vertical_index_at_top_of_deep_convection_for_convective_columns
-    - vertical_index_of_deep_convection_launch_level_for_convective_columns
-    - zhang_mcfarlane_convective_available_potential_energy
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/zm_evap_tendency_diagnostics.meta
+atmospheric_physics/schemes/sima_diagnostics/zm_evap_tendency_diagnostics.meta
 
     - ccpp_error_code
     - ccpp_error_message
@@ -169,7 +37,94 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/rk_stratiform_diagnostics.meta
+atmospheric_physics/schemes/sima_diagnostics/check_energy_gmean_diagnostics.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - flag_for_energy_global_means_output
+    - global_mean_heating_rate_correction_for_energy_conservation
+    - global_mean_vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
+    - global_mean_vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/convective_cloud_cover_diagnostics.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - deep_convective_cloud_area_fraction
+    - shallow_convective_cloud_area_fraction
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/zm_tendency_diagnostics.meta
+
+    - ccpp_constituent_properties
+    - ccpp_constituent_tendencies
+    - ccpp_error_code
+    - ccpp_error_message
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/convect_shallow_diagnostics.meta
+
+    - atmosphere_convective_mass_flux_due_to_all_convection
+    - atmosphere_convective_mass_flux_due_to_shallow_convection
+    - ccpp_constituent_properties
+    - ccpp_constituent_tendencies
+    - ccpp_error_code
+    - ccpp_error_message
+    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_all_convection
+    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+    - frozen_precipitation_flux_at_interface_due_to_shallow_convection
+    - in_cloud_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+    - latent_heat_of_vaporization_times_sum_of_water_vapor_and_cloud_liquid_flux_due_to_shallow_convection
+    - liquid_water_static_energy_flux_due_to_shallow_convection
+    - lwe_precipitation_rate_at_surface_due_to_shallow_convection
+    - number_of_ccpp_constituents
+    - precipitation_flux_at_interface_due_to_shallow_convection
+    - pressure_at_cloud_base_for_all_convection
+    - pressure_at_cloud_top_for_all_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_shallow_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_shallow_convection
+    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection_excluding_subcloud_evaporation
+    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+    - vertical_index_at_cloud_base_for_all_convection
+    - vertical_index_at_cloud_top_for_all_convection
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/check_energy_diagnostics.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - cumulative_total_energy_boundary_flux_using_physics_energy_formula
+    - cumulative_total_water_boundary_flux
+    - ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
+    - specific_heat_of_air_used_in_dycore
+    - vertically_integrated_total_energy_using_physics_energy_formula
+    - vertically_integrated_total_water
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/sima_state_diagnostics.meta
+
+    - air_pressure_at_interface
+    - air_pressure_of_dry_air_at_interface
+    - ccpp_constituent_properties
+    - ccpp_constituents
+    - ccpp_error_code
+    - ccpp_error_message
+    - geopotential_height_wrt_surface_at_interface
+    - ln_air_pressure_at_interface
+    - ln_air_pressure_of_dry_air_at_interface
+    - surface_air_pressure
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/rk_stratiform_diagnostics.meta
 
     - accretion_of_cloud_ice_by_snow
     - accretion_of_cloud_liquid_water_by_rain
@@ -205,7 +160,40 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/tropopause_diagnostics.meta
+atmospheric_physics/schemes/sima_diagnostics/rayleigh_friction_diagnostics.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/zm_convr_tendency_diagnostics.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/check_energy_fix_diagnostics.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - net_sensible_heat_flux_through_top_and_bottom_of_atmosphere_column
+    - vertically_integrated_total_energy_using_dycore_energy_formula
+    - vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
+    - vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/kessler_diagnostics.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/tropopause_diagnostics.meta
 
     - ccpp_error_code
     - ccpp_error_message
@@ -235,14 +223,7 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/rayleigh_friction_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/compute_cloud_fraction_diagnostics.meta
+atmospheric_physics/schemes/sima_diagnostics/compute_cloud_fraction_diagnostics.meta
 
     - ccpp_error_code
     - ccpp_error_message
@@ -250,159 +231,43 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/sima_state_diagnostics.meta
+atmospheric_physics/schemes/sima_diagnostics/zm_momtran_tendency_diagnostics.meta
 
-    - air_pressure_at_interface
-    - air_pressure_of_dry_air_at_interface
-    - ccpp_constituent_properties
-    - ccpp_constituents
     - ccpp_error_code
     - ccpp_error_message
-    - geopotential_height_wrt_surface_at_interface
-    - ln_air_pressure_at_interface
-    - ln_air_pressure_of_dry_air_at_interface
+
+--------------------------
+
+atmospheric_physics/schemes/sima_diagnostics/zm_diagnostics.meta
+
+    - atmosphere_convective_mass_flux_due_to_deep_convection
+    - atmosphere_downdraft_convective_mass_flux_for_deep_convection_for_convective_columns
+    - atmosphere_updraft_convective_mass_flux_for_deep_convection_for_convective_columns
+    - ccpp_error_code
+    - ccpp_error_message
+    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_deep_convection
+    - frozen_precipitation_flux_at_interface_due_to_deep_convection
+    - horizontal_index_of_convective_columns_for_deep_convection_for_convective_columns
+    - in_cloud_eastward_wind_in_downdraft_due_to_deep_convection
+    - in_cloud_eastward_wind_in_updraft_due_to_deep_convection
+    - in_cloud_northward_wind_in_downdraft_due_to_deep_convection
+    - in_cloud_northward_wind_in_updraft_due_to_deep_convection
+    - lwe_precipitation_rate_at_surface_due_to_deep_convection
+    - precipitation_flux_at_interface_due_to_deep_convection
     - surface_air_pressure
+    - tendency_of_eastward_wind_due_to_zhang_mcfarlane_deep_convective_downdraft_pressure_gradient_term
+    - tendency_of_eastward_wind_due_to_zhang_mcfarlane_deep_convective_updraft_pressure_gradient_term
+    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection
+    - tendency_of_northward_wind_due_to_zhang_mcfarlane_deep_convective_downdraft_pressure_gradient_term
+    - tendency_of_northward_wind_due_to_zhang_mcfarlane_deep_convective_updraft_pressure_gradient_term
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection
+    - vertical_index_at_top_of_deep_convection_for_convective_columns
+    - vertical_index_of_deep_convection_launch_level_for_convective_columns
+    - zhang_mcfarlane_convective_available_potential_energy
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/kessler_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/convective_cloud_cover_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - deep_convective_cloud_area_fraction
-    - shallow_convective_cloud_area_fraction
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/convect_shallow_diagnostics.meta
-
-    - atmosphere_convective_mass_flux_due_to_all_convection
-    - atmosphere_convective_mass_flux_due_to_shallow_convection
-    - ccpp_constituent_properties
-    - ccpp_constituent_tendencies
-    - ccpp_error_code
-    - ccpp_error_message
-    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_all_convection
-    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-    - frozen_precipitation_flux_at_interface_due_to_shallow_convection
-    - in_cloud_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-    - liquid_water_static_energy_flux_due_to_shallow_convection
-    - lwe_precipitation_rate_at_surface_due_to_shallow_convection
-    - number_of_ccpp_constituents
-    - precipitation_flux_at_interface_due_to_shallow_convection
-    - pressure_at_cloud_base_for_all_convection
-    - pressure_at_cloud_top_for_all_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_shallow_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_shallow_convection
-    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection_excluding_subcloud_evaporation
-    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
-    - total_water_flux_due_to_shallow_convection
-    - vertical_index_at_cloud_base_for_all_convection
-    - vertical_index_at_cloud_top_for_all_convection
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/sima_tend_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/zm_tendency_diagnostics.meta
-
-    - ccpp_constituent_properties
-    - ccpp_constituent_tendencies
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/zm_convr_tendency_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/cloud_particle_sedimentation_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - stratiform_lwe_cloud_ice_surface_flux_due_to_sedimentation
-    - stratiform_rain_flux_at_surface_due_to_sedimentation
-    - tendency_of_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
-    - tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
-    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/zm_momtran_tendency_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/check_energy_gmean_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - flag_for_energy_global_means_output
-    - global_mean_heating_rate_correction_for_energy_conservation
-    - global_mean_vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
-    - global_mean_vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/sima_diagnostics/check_energy_diagnostics.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - cumulative_total_energy_boundary_flux_using_physics_energy_formula
-    - cumulative_total_water_boundary_flux
-    - ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
-    - specific_heat_of_air_used_in_dycore
-    - vertically_integrated_total_energy_using_physics_energy_formula
-    - vertically_integrated_total_water
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/kessler/kessler_update.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/kessler/kessler.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - scheme_name
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/mmm/mmm_physics_compat.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - tendency_of_x_wind_due_to_pbl_processes
-    - tendency_of_y_wind_due_to_pbl_processes
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/mmm/bl_gwdo_compat.meta
+atmospheric_physics/schemes/mmm/bl_gwdo_compat.meta
 
     - air_pressure_at_interface
     - atmosphere_x_stress_due_to_orographic_gwd
@@ -433,7 +298,277 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/zhang_mcfarlane/zm_conv_momtran.meta
+atmospheric_physics/schemes/mmm/mmm_physics_compat.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - tendency_of_x_wind_due_to_pbl_processes
+    - tendency_of_y_wind_due_to_pbl_processes
+
+--------------------------
+
+atmospheric_physics/schemes/tj2016/tj2016_precip.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - gas_constant_of_water_vapor
+    - lwe_large_scale_precipitation_rate_at_surface
+    - ratio_of_water_vapor_to_dry_air_molecular_weights
+    - scheme_name
+    - sum_of_sigma_pressure_hybrid_coordinate_a_coefficient_and_sigma_pressure_hybrid_coordinate_b_coefficient
+
+--------------------------
+
+atmospheric_physics/schemes/tj2016/tj2016_sfc_pbl_hs.meta
+
+    - air_pressure_at_interface
+    - ccpp_error_code
+    - ccpp_error_message
+    - eddy_heat_diffusivity
+    - eddy_momentum_diffusivity
+    - gas_constant_of_water_vapor
+    - ln_air_pressure_at_interface
+    - pi_constant
+    - ratio_of_water_vapor_to_dry_air_molecular_weights
+    - scheme_name
+    - sea_surface_temperature_from_coupler
+    - sum_of_sigma_pressure_hybrid_coordinate_a_coefficient_and_sigma_pressure_hybrid_coordinate_b_coefficient
+    - surface_air_pressure
+    - surface_eastward_wind_stress
+    - surface_evaporation_rate
+    - surface_northward_wind_stress
+    - surface_upward_sensible_heat_flux
+    - tendency_of_air_temperature_due_to_diabatic_heating
+    - tendency_of_air_temperature_due_to_vertical_diffusion
+    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_due_to_vertical_diffusion
+
+--------------------------
+
+atmospheric_physics/schemes/cloud_fraction/convective_cloud_cover.meta
+
+    - atmosphere_convective_mass_flux_due_to_all_convection
+    - atmosphere_convective_mass_flux_due_to_shallow_convection
+    - ccpp_error_code
+    - ccpp_error_message
+    - deep_convective_cloud_area_fraction
+    - flag_for_cloud_area_fraction_to_use_shallow_convection_calculated_cloud_area_fraction
+    - shallow_convective_cloud_area_fraction
+    - shallow_convective_cloud_area_fraction_from_shallow_convection
+    - tunable_parameter_for_deep_convection_1_for_cloud_fraction
+    - tunable_parameter_for_deep_convection_2_for_cloud_fraction
+    - tunable_parameter_for_shallow_convection_1_for_cloud_fraction
+    - tunable_parameter_for_shallow_convection_2_for_cloud_fraction
+    - vertical_layer_index_of_cloud_fraction_top
+
+--------------------------
+
+atmospheric_physics/schemes/cloud_fraction/compute_cloud_fraction.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - cloud_area_fraction
+    - cloud_area_fraction_from_relative_humidity_method
+    - control_for_ice_cloud_fraction
+    - deep_convective_cloud_area_fraction
+    - do_ice_cloud_fraction_for_cloud_fraction
+    - do_no_stratification_based_cloud_fraction
+    - do_relative_humidity_perturbation_for_cloud_fraction
+    - do_vavrus_freeze_dry_adjustment_for_cloud_fraction
+    - freezing_point_of_water
+    - land_area_fraction_from_coupler
+    - lwe_surface_snow_depth_over_land_from_coupler
+    - ocean_area_fraction_from_coupler
+    - ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
+    - reference_temperature_lapse_rate
+    - relative_humidity_threshold_for_cloud_formation
+    - sea_surface_temperature_from_coupler
+    - shallow_convective_cloud_area_fraction
+    - stratiform_cloud_area_fraction
+    - stratiform_cloud_ice_area_fraction
+    - stratiform_cloud_liquid_area_fraction
+    - surface_air_pressure
+    - tunable_parameter_for_adjustment_to_minimum_relative_humidity_for_low_stable_clouds_for_land_without_snow_cover_for_cloud_fraction
+    - tunable_parameter_for_bottom_pressure_bound_for_mid_level_liquid_stratus_for_cloud_fraction
+    - tunable_parameter_for_critical_relative_humidity_for_ice_clouds_for_cloud_fraction_using_wilson_and_ballard_scheme
+    - tunable_parameter_for_minimum_relative_humidity_for_high_stable_clouds_for_cloud_fraction
+    - tunable_parameter_for_minimum_relative_humidity_for_low_stable_clouds_for_cloud_fraction
+    - tunable_parameter_for_top_pressure_bound_for_mid_level_clouds_for_cloud_fraction
+    - vertical_layer_index_of_cloud_fraction_top
+
+--------------------------
+
+atmospheric_physics/schemes/cloud_fraction/cloud_fraction_fice.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - freezing_point_of_water
+    - mass_fraction_of_ice_content_within_stratiform_cloud
+    - mass_fraction_of_snow_content_within_stratiform_cloud
+    - vertical_layer_index_of_cloud_fraction_top
+
+--------------------------
+
+atmospheric_physics/schemes/cloud_fraction/set_cloud_fraction_top.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - vertical_layer_index_of_cloud_fraction_top
+    - vertical_layer_index_of_troposphere_cloud_physics_top
+
+--------------------------
+
+atmospheric_physics/schemes/hack_shallow/convect_shallow_sum_to_deep.meta
+
+    - atmosphere_convective_mass_flux_due_to_all_convection
+    - atmosphere_convective_mass_flux_due_to_deep_convection
+    - atmosphere_convective_mass_flux_due_to_shallow_convection
+    - ccpp_error_code
+    - ccpp_error_message
+    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_all_convection
+    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_deep_convection
+    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+    - pressure_at_cloud_base_for_all_convection
+    - pressure_at_cloud_top_for_all_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection_excluding_subcloud_evaporation
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection_excluding_subcloud_evaporation
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection_excluding_subcloud_evaporation
+    - vertical_index_at_cloud_base_for_all_convection
+    - vertical_index_at_cloud_base_for_shallow_convection
+    - vertical_index_at_cloud_top_for_all_convection
+    - vertical_index_at_cloud_top_for_shallow_convection
+    - vertical_index_at_top_of_deep_convection_for_convective_columns
+    - vertical_index_of_deep_convection_launch_level_for_convective_columns
+    - vertically_integrated_cloud_liquid_water_tendency_due_to_all_convection_to_be_applied_later_in_time_loop
+    - vertically_integrated_cloud_liquid_water_tendency_due_to_shallow_convection_to_be_applied_later_in_time_loop
+
+--------------------------
+
+atmospheric_physics/schemes/hack_shallow/hack_convect_shallow.meta
+
+    - atmosphere_convective_mass_flux_due_to_shallow_convection
+    - ccpp_constituent_properties
+    - ccpp_constituent_tendencies
+    - ccpp_constituents
+    - ccpp_error_code
+    - ccpp_error_message
+    - characteristic_adjustment_time_for_shallow_convection
+    - convective_water_vapor_wrt_moist_air_and_condensed_water_perturbation_due_to_pbl_eddies
+    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+    - flag_for_cloud_area_fraction_to_use_shallow_convection_calculated_cloud_area_fraction
+    - in_cloud_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+    - latent_heat_of_vaporization_times_sum_of_water_vapor_and_cloud_liquid_flux_due_to_shallow_convection
+    - liquid_water_static_energy_flux_due_to_shallow_convection
+    - lwe_precipitation_rate_at_surface_due_to_shallow_convection
+    - net_liquid_and_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
+    - number_of_ccpp_constituents
+    - rain_water_autoconversion_coefficient_for_shallow_convection
+    - reference_pressure_at_interface
+    - scheme_name
+    - shallow_convective_cloud_area_fraction_from_shallow_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection_excluding_subcloud_evaporation
+    - vertical_index_at_cloud_base_for_shallow_convection
+    - vertical_index_at_cloud_top_for_shallow_convection
+    - vertical_layer_index_of_cloud_fraction_top
+    - vertically_integrated_cloud_liquid_water_tendency_due_to_shallow_convection_to_be_applied_later_in_time_loop
+
+--------------------------
+
+atmospheric_physics/schemes/hack_shallow/set_shallow_conv_fluxes_to_general.meta
+
+    - lwe_precipitation_rate_at_surface_due_to_convection
+    - lwe_precipitation_rate_at_surface_due_to_shallow_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection_excluding_subcloud_evaporation
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection_excluding_subcloud_evaporation
+
+--------------------------
+
+atmospheric_physics/schemes/hack_shallow/set_general_conv_fluxes_to_shallow.meta
+
+    - frozen_precipitation_flux_at_interface_due_to_convection
+    - frozen_precipitation_flux_at_interface_due_to_shallow_convection
+    - lwe_frozen_precipitation_rate_at_surface_due_to_convection
+    - lwe_frozen_precipitation_rate_at_surface_due_to_shallow_convection
+    - lwe_precipitation_rate_at_surface_due_to_convection
+    - lwe_precipitation_rate_at_surface_due_to_shallow_convection
+    - net_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
+    - precipitation_flux_at_interface_due_to_convection
+    - precipitation_flux_at_interface_due_to_shallow_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_shallow_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_shallow_convection
+    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_convection
+    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_shallow_convection
+
+--------------------------
+
+atmospheric_physics/schemes/kessler/kessler_update.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+
+--------------------------
+
+atmospheric_physics/schemes/kessler/kessler.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - scheme_name
+
+--------------------------
+
+atmospheric_physics/schemes/dry_adiabatic_adjust/dadadj.meta
+
+    - air_pressure_at_interface
+    - binary_indicator_for_dry_adiabatic_adjusted_grid_cell
+    - ccpp_error_code
+    - ccpp_error_message
+    - number_of_iterations_for_dry_adiabatic_adjustment_algorithm_convergence
+    - number_of_vertical_levels_from_model_top_where_dry_adiabatic_adjustment_occurs
+    - scheme_name
+    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+
+--------------------------
+
+atmospheric_physics/schemes/thermo_water_update/thermo_water_update.meta
+
+    - ccpp_constituents
+    - specific_heat_of_air_used_in_dycore
+    - total_energy_formula_for_dycore
+
+--------------------------
+
+atmospheric_physics/schemes/zhang_mcfarlane/zm_conv_options.meta
+
+    - cape_threshold_for_zhang_mcfarlane_deep_convection_scheme
+    - cloud_condensate_to_precipitation_autoconversion_coefficient_over_land_for_zhang_mcfarlane_deep_convection_scheme
+    - cloud_condensate_to_precipitation_autoconversion_coefficient_over_ocean_for_zhang_mcfarlane_deep_convection_scheme
+    - deep_convective_adjustment_timescale_for_zhang_mcfarlane_deep_convection_scheme
+    - entrainment_rate_for_cape_for_zhang_mcfarlane_deep_convection_scheme
+    - flag_for_no_deep_convection_in_pbl
+    - flag_for_well_mixed_pbl_parcel_property_for_zhang_mcfarlane_deep_convection_scheme
+    - fraction_of_pbl_depth_mixed_for_initial_zhang_mcfarlane_parcel_properties
+    - momentum_transport_parameter_for_vertical_pressure_gradient_force_for_downdraft_for_zhang_mcfarlane_deep_convection_scheme
+    - momentum_transport_parameter_for_vertical_pressure_gradient_force_for_updraft_for_zhang_mcfarlane_deep_convection_scheme
+    - number_of_negative_buoyancy_layers_allowed_before_convection_top_for_zhang_mcfarlane_deep_convection_scheme
+    - parcel_temperature_perturbation_for_zhang_mcfarlane_deep_convection_scheme
+    - tunable_evaporation_efficiency_over_land_for_zhang_mcfarlane_deep_convection_scheme
+    - tunable_evaporation_efficiency_over_ocean_for_zhang_mcfarlane_deep_convection_scheme
+
+--------------------------
+
+atmospheric_physics/schemes/zhang_mcfarlane/set_deep_conv_fluxes_to_general.meta
+
+    - lwe_precipitation_rate_at_surface_due_to_convection
+    - lwe_precipitation_rate_at_surface_due_to_deep_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection_excluding_subcloud_evaporation
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection_excluding_subcloud_evaporation
+
+--------------------------
+
+atmospheric_physics/schemes/zhang_mcfarlane/zm_conv_momtran.meta
 
     - atmosphere_detrainment_convective_mass_flux_for_deep_convection_for_convective_columns
     - atmosphere_downdraft_convective_mass_flux_for_deep_convection_for_convective_columns
@@ -465,16 +600,7 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/zhang_mcfarlane/set_deep_conv_fluxes_to_general.meta
-
-    - lwe_precipitation_rate_at_surface_due_to_convection
-    - lwe_precipitation_rate_at_surface_due_to_deep_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection_excluding_subcloud_evaporation
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection_excluding_subcloud_evaporation
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/zhang_mcfarlane/zm_conv_evap.meta
+atmospheric_physics/schemes/zhang_mcfarlane/zm_conv_evap.meta
 
     - ccpp_error_code
     - ccpp_error_message
@@ -499,55 +625,7 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/zhang_mcfarlane/set_general_conv_fluxes_to_deep.meta
-
-    - frozen_precipitation_flux_at_interface_due_to_convection
-    - frozen_precipitation_flux_at_interface_due_to_deep_convection
-    - lwe_frozen_precipitation_rate_at_surface_due_to_convection
-    - lwe_frozen_precipitation_rate_at_surface_due_to_deep_convection
-    - lwe_precipitation_rate_at_surface_due_to_convection
-    - lwe_precipitation_rate_at_surface_due_to_deep_convection
-    - precipitation_flux_at_interface_due_to_convection
-    - precipitation_flux_at_interface_due_to_deep_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_deep_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_convection
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_deep_convection
-    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_convection
-    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection
-    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/zhang_mcfarlane/zm_conv_convtran.meta
-
-    - atmosphere_detrainment_convective_mass_flux_for_deep_convection_for_convective_columns
-    - atmosphere_downdraft_convective_mass_flux_for_deep_convection_for_convective_columns
-    - atmosphere_downdraft_entrainment_convective_mass_flux_for_deep_convection_for_convective_columns
-    - atmosphere_updraft_convective_mass_flux_for_deep_convection_for_convective_columns
-    - atmosphere_updraft_entrainment_convective_mass_flux_for_deep_convection_for_convective_columns
-    - ccpp_constituent_properties
-    - ccpp_constituent_tendencies
-    - ccpp_constituents
-    - ccpp_error_code
-    - ccpp_error_message
-    - current_timestep_number
-    - flag_for_tracer_transport_by_zhang_mcfarlane_deep_scheme
-    - fraction_of_water_insoluble_convectively_transported_species
-    - horizontal_index_of_convective_columns_for_deep_convection_for_convective_columns
-    - index_of_first_column_of_gathered_deep_convection_arrays
-    - index_of_last_column_of_gathered_deep_convection_arrays
-    - number_of_ccpp_constituents
-    - pressure_thickness_for_deep_convection_for_convective_columns
-    - pressure_thickness_for_subcloud_layer_for_deep_convection_for_convective_columns
-    - scheme_name
-    - vertical_index_at_top_of_deep_convection_for_convective_columns
-    - vertical_index_of_deep_convection_launch_level_for_convective_columns
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/zhang_mcfarlane/zm_convr.meta
+atmospheric_physics/schemes/zhang_mcfarlane/zm_convr.meta
 
     - air_pressure_at_interface
     - atmosphere_convective_mass_flux_due_to_deep_convection
@@ -603,215 +681,188 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/zhang_mcfarlane/zm_conv_options.meta
+atmospheric_physics/schemes/zhang_mcfarlane/set_general_conv_fluxes_to_deep.meta
 
-    - cape_threshold_for_zhang_mcfarlane_deep_convection_scheme
-    - cloud_condensate_to_precipitation_autoconversion_coefficient_over_land_for_zhang_mcfarlane_deep_convection_scheme
-    - cloud_condensate_to_precipitation_autoconversion_coefficient_over_ocean_for_zhang_mcfarlane_deep_convection_scheme
-    - deep_convective_adjustment_timescale_for_zhang_mcfarlane_deep_convection_scheme
-    - entrainment_rate_for_cape_for_zhang_mcfarlane_deep_convection_scheme
-    - flag_for_no_deep_convection_in_pbl
-    - flag_for_well_mixed_pbl_parcel_property_for_zhang_mcfarlane_deep_convection_scheme
-    - fraction_of_pbl_depth_mixed_for_initial_zhang_mcfarlane_parcel_properties
-    - momentum_transport_parameter_for_vertical_pressure_gradient_force_for_downdraft_for_zhang_mcfarlane_deep_convection_scheme
-    - momentum_transport_parameter_for_vertical_pressure_gradient_force_for_updraft_for_zhang_mcfarlane_deep_convection_scheme
-    - number_of_negative_buoyancy_layers_allowed_before_convection_top_for_zhang_mcfarlane_deep_convection_scheme
-    - parcel_temperature_perturbation_for_zhang_mcfarlane_deep_convection_scheme
-    - tunable_evaporation_efficiency_over_land_for_zhang_mcfarlane_deep_convection_scheme
-    - tunable_evaporation_efficiency_over_ocean_for_zhang_mcfarlane_deep_convection_scheme
+    - frozen_precipitation_flux_at_interface_due_to_convection
+    - frozen_precipitation_flux_at_interface_due_to_deep_convection
+    - lwe_frozen_precipitation_rate_at_surface_due_to_convection
+    - lwe_frozen_precipitation_rate_at_surface_due_to_deep_convection
+    - lwe_precipitation_rate_at_surface_due_to_convection
+    - lwe_precipitation_rate_at_surface_due_to_deep_convection
+    - precipitation_flux_at_interface_due_to_convection
+    - precipitation_flux_at_interface_due_to_deep_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_and_melting_of_frozen_precipitation_due_to_deep_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_convection
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_frozen_precipitation_production_due_to_deep_convection
+    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_convection
+    - tendency_of_frozen_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_convection
+    - tendency_of_precipitation_wrt_moist_air_and_condensed_water_due_to_deep_convection
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/conservation_adjust/dme_adjust/dme_adjust.meta
+atmospheric_physics/schemes/zhang_mcfarlane/zm_conv_convtran.meta
+
+    - atmosphere_detrainment_convective_mass_flux_for_deep_convection_for_convective_columns
+    - atmosphere_downdraft_convective_mass_flux_for_deep_convection_for_convective_columns
+    - atmosphere_downdraft_entrainment_convective_mass_flux_for_deep_convection_for_convective_columns
+    - atmosphere_updraft_convective_mass_flux_for_deep_convection_for_convective_columns
+    - atmosphere_updraft_entrainment_convective_mass_flux_for_deep_convection_for_convective_columns
+    - ccpp_constituent_properties
+    - ccpp_constituent_tendencies
+    - ccpp_constituents
+    - ccpp_error_code
+    - ccpp_error_message
+    - current_timestep_number
+    - flag_for_tracer_transport_by_zhang_mcfarlane_deep_scheme
+    - fraction_of_water_insoluble_convectively_transported_species
+    - horizontal_index_of_convective_columns_for_deep_convection_for_convective_columns
+    - index_of_first_column_of_gathered_deep_convection_arrays
+    - index_of_last_column_of_gathered_deep_convection_arrays
+    - number_of_ccpp_constituents
+    - pressure_thickness_for_deep_convection_for_convective_columns
+    - pressure_thickness_for_subcloud_layer_for_deep_convection_for_convective_columns
+    - scheme_name
+    - vertical_index_at_top_of_deep_convection_for_convective_columns
+    - vertical_index_of_deep_convection_launch_level_for_convective_columns
+
+--------------------------
+
+atmospheric_physics/schemes/utilities/to_be_ccppized_temporary.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+
+--------------------------
+
+atmospheric_physics/schemes/utilities/geopotential_temp.meta
 
     - air_pressure_at_interface
     - ccpp_constituent_properties
     - ccpp_constituents
     - ccpp_error_code
     - ccpp_error_message
-    - is_moist_basis_dycore
+    - geopotential_height_wrt_surface_at_interface
     - ln_air_pressure_at_interface
     - number_of_ccpp_constituents
-    - surface_air_pressure
-    - total_ice_water_mixing_ratio_wrt_moist_air_and_condensed_water_before_physics
-    - total_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water_before_physics
-    - water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_before_physics
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/conservation_adjust/check_energy/dycore_energy_consistency_adjust.meta
+atmospheric_physics/schemes/utilities/state_converters.meta
 
     - ccpp_error_code
     - ccpp_error_message
-    - flag_for_dycore_energy_consistency_adjustment
-    - ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/conservation_adjust/check_energy/check_energy_zero_fluxes.meta
+atmospheric_physics/schemes/utilities/qneg.meta
 
-    - ccpp_error_code
-    - ccpp_error_message
-    - net_liquid_and_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
-    - net_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
-    - net_sensible_heat_flux_through_top_and_bottom_of_atmosphere_column
-    - net_water_vapor_fluxes_through_top_and_bottom_of_atmosphere_column
-    - scheme_name
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/conservation_adjust/check_energy/check_energy_chng.meta
-
-    - air_pressure_of_dry_air_at_interface
-    - air_temperature_at_start_of_physics_timestep
+    - ccpp_constituent_minimum_values
+    - ccpp_constituent_properties
     - ccpp_constituents
     - ccpp_error_code
     - ccpp_error_message
-    - cumulative_total_energy_boundary_flux_using_physics_energy_formula
-    - cumulative_total_water_boundary_flux
-    - flag_for_energy_conservation_warning
-    - geopotential_height_wrt_surface_at_start_of_physics_timestep
-    - latent_heat_of_fusion_of_water_at_0c
-    - net_liquid_and_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
-    - net_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
-    - net_sensible_heat_flux_through_top_and_bottom_of_atmosphere_column
-    - net_water_vapor_fluxes_through_top_and_bottom_of_atmosphere_column
-    - number_of_atmosphere_columns_with_significant_energy_or_water_imbalances
     - number_of_ccpp_constituents
-    - ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
-    - scheme_name
-    - specific_heat_of_air_used_in_dycore
-    - total_energy_formula_for_dycore
-    - total_energy_formula_for_physics
-    - vertically_integrated_total_energy_using_dycore_energy_formula
-    - vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
-    - vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
-    - vertically_integrated_total_energy_using_physics_energy_formula
-    - vertically_integrated_total_energy_using_physics_energy_formula_at_start_of_physics_timestep
-    - vertically_integrated_total_water
-    - vertically_integrated_total_water_at_start_of_physics_timestep
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/conservation_adjust/check_energy/check_energy_fix.meta
-
-    - air_pressure_at_interface
-    - ccpp_error_code
-    - ccpp_error_message
-    - global_mean_heating_rate_correction_for_energy_conservation
-    - net_sensible_heat_flux_through_top_and_bottom_of_atmosphere_column
     - scheme_name
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/conservation_adjust/check_energy/check_energy_save_teout.meta
+atmospheric_physics/schemes/utilities/physics_tendency_updaters.meta
 
+    - ccpp_constituent_tendencies
+    - ccpp_constituents
     - ccpp_error_code
     - ccpp_error_message
-    - vertically_integrated_total_energy_using_dycore_energy_formula
-    - vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/conservation_adjust/check_energy/check_energy_scaling.meta
+atmospheric_physics/schemes/utilities/static_energy.meta
 
     - ccpp_error_code
     - ccpp_error_message
-    - ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
-    - specific_heat_of_air_used_in_dycore
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/conservation_adjust/check_energy/check_energy_gmean/check_energy_gmean.meta
-
-    - air_pressure_at_interface
-    - ccpp_error_code
-    - ccpp_error_message
-    - global_mean_air_pressure_at_top_of_atmosphere_model
-    - global_mean_heating_rate_correction_for_energy_conservation
-    - global_mean_surface_air_pressure
-    - global_mean_total_energy_correction_for_energy_conservation
-    - global_mean_vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
-    - global_mean_vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
-    - vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
-    - vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/cloud_fraction/cloud_fraction_fice.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - freezing_point_of_water
-    - mass_fraction_of_ice_content_within_stratiform_cloud
-    - mass_fraction_of_snow_content_within_stratiform_cloud
-    - vertical_layer_index_of_cloud_fraction_top
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/cloud_fraction/set_cloud_fraction_top.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - vertical_layer_index_of_cloud_fraction_top
-    - vertical_layer_index_of_troposphere_cloud_physics_top
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/cloud_fraction/compute_cloud_fraction.meta
+atmospheric_physics/schemes/rasch_kristjansson/rk_stratiform.meta
 
     - ccpp_error_code
     - ccpp_error_message
     - cloud_area_fraction
-    - cloud_area_fraction_from_relative_humidity_method
-    - control_for_ice_cloud_fraction
+    - cloud_water_mixing_ratio_wrt_moist_air_and_condensed_water_on_previous_timestep
     - deep_convective_cloud_area_fraction
-    - do_ice_cloud_fraction_for_cloud_fraction
-    - do_no_stratification_based_cloud_fraction
-    - do_relative_humidity_perturbation_for_cloud_fraction
-    - do_vavrus_freeze_dry_adjustment_for_cloud_fraction
+    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_all_convection
     - freezing_point_of_water
     - land_area_fraction_from_coupler
+    - latent_heat_of_fusion_of_water_at_0c
+    - lwe_large_scale_precipitation_rate_at_surface
+    - lwe_snow_and_cloud_ice_precipitation_rate_at_surface_due_to_microphysics
+    - lwe_snow_precipitation_rate_at_surface_due_to_microphysics
+    - lwe_stratiform_precipitation_rate_at_surface
     - lwe_surface_snow_depth_over_land_from_coupler
+    - mass_fraction_of_ice_content_within_stratiform_cloud
+    - net_condensation_rate_due_to_microphysics
     - ocean_area_fraction_from_coupler
+    - rate_of_condensation_minus_evaporation_for_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
+    - rate_of_condensation_minus_evaporation_for_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+    - rate_of_evaporation_of_precipitation_due_to_microphysics
     - ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
     - reference_temperature_lapse_rate
+    - relative_humidity_divided_by_cloud_area_fraction_perturbation
     - relative_humidity_threshold_for_cloud_formation
+    - sea_ice_area_fraction_from_coupler
     - sea_surface_temperature_from_coupler
     - shallow_convective_cloud_area_fraction
-    - stratiform_cloud_area_fraction
-    - stratiform_cloud_ice_area_fraction
-    - stratiform_cloud_liquid_area_fraction
+    - smoothed_land_area_fraction
+    - stratiform_cloud_water_surface_flux_due_to_sedimentation
+    - stratiform_lwe_cloud_ice_surface_flux_due_to_sedimentation
+    - stratiform_rain_flux_at_surface_due_to_sedimentation
     - surface_air_pressure
-    - tunable_parameter_for_adjustment_to_minimum_relative_humidity_for_low_stable_clouds_for_land_without_snow_cover_for_cloud_fraction
-    - tunable_parameter_for_bottom_pressure_bound_for_mid_level_liquid_stratus_for_cloud_fraction
-    - tunable_parameter_for_critical_relative_humidity_for_ice_clouds_for_cloud_fraction_using_wilson_and_ballard_scheme
-    - tunable_parameter_for_minimum_relative_humidity_for_high_stable_clouds_for_cloud_fraction
-    - tunable_parameter_for_minimum_relative_humidity_for_low_stable_clouds_for_cloud_fraction
-    - tunable_parameter_for_top_pressure_bound_for_mid_level_clouds_for_cloud_fraction
+    - tendency_of_air_temperature_not_due_to_microphysics
+    - tendency_of_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
+    - tendency_of_cloud_ice_mixing_ratio_wrt_to_moist_air_and_condensed_water_due_to_ice_to_snow_autoconversion
+    - tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+    - tendency_of_cloud_liquid_water_mixing_ratio_wrt_to_moist_air_and_condensed_water_due_to_liquid_to_rain_autoconversion
+    - tendency_of_cloud_water_mixing_ratio_wrt_moist_air_and_condensed_water_not_due_to_microphysics
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_cloud_ice_and_cloud_liquid_repartitioning
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_condensation_minus_evaporation
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_of_precipitation
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_freezing_of_precipitation
+    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_snow_melt
+    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_not_due_to_microphysics
     - vertical_layer_index_of_cloud_fraction_top
+    - vertically_integrated_cloud_liquid_water_tendency_due_to_all_convection_to_be_applied_later_in_time_loop
+    - water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_on_previous_timestep
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/cloud_fraction/convective_cloud_cover.meta
+atmospheric_physics/schemes/rasch_kristjansson/cloud_particle_sedimentation.meta
 
-    - atmosphere_convective_mass_flux_due_to_all_convection
-    - atmosphere_convective_mass_flux_due_to_shallow_convection
+    - air_pressure_at_interface
     - ccpp_error_code
     - ccpp_error_message
-    - deep_convective_cloud_area_fraction
-    - flag_for_cloud_area_fraction_to_use_shallow_convection_calculated_cloud_area_fraction
-    - shallow_convective_cloud_area_fraction
-    - shallow_convective_cloud_area_fraction_from_shallow_convection
-    - tunable_parameter_for_deep_convection_1_for_cloud_fraction
-    - tunable_parameter_for_deep_convection_2_for_cloud_fraction
-    - tunable_parameter_for_shallow_convection_1_for_cloud_fraction
-    - tunable_parameter_for_shallow_convection_2_for_cloud_fraction
-    - vertical_layer_index_of_cloud_fraction_top
+    - cloud_area_fraction
+    - freezing_point_of_water
+    - land_area_fraction_from_coupler
+    - latent_heat_of_fusion_of_water_at_0c
+    - lwe_surface_snow_depth_over_land_from_coupler
+    - magnitude_of_vertical_pressure_velocity_of_cloud_ice_due_to_sedimentation
+    - magnitude_of_vertical_pressure_velocity_of_cloud_liquid_water_due_to_sedimentation
+    - ocean_area_fraction_from_coupler
+    - sea_ice_area_fraction_from_coupler
+    - smoothed_land_area_fraction
+    - stratiform_lwe_cloud_ice_surface_flux_due_to_sedimentation
+    - stratiform_rain_flux_at_surface_due_to_sedimentation
+    - tendency_of_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
+    - tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+    - tunable_parameter_for_autoconversion_of_cold_ice_for_rk_microphysics
+    - tunable_parameter_for_ice_fall_velocity_for_rk_microphysics
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/rasch_kristjansson/prognostic_cloud_water.meta
+atmospheric_physics/schemes/rasch_kristjansson/prognostic_cloud_water.meta
 
     - accretion_of_cloud_ice_by_snow
     - accretion_of_cloud_liquid_water_by_rain
@@ -868,227 +919,123 @@ Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/rasch_kristjansson/cloud_particle_sedimentation.meta
+atmospheric_physics/schemes/conservation_adjust/dme_adjust/dme_adjust.meta
 
     - air_pressure_at_interface
-    - ccpp_error_code
-    - ccpp_error_message
-    - cloud_area_fraction
-    - freezing_point_of_water
-    - land_area_fraction_from_coupler
-    - latent_heat_of_fusion_of_water_at_0c
-    - lwe_surface_snow_depth_over_land_from_coupler
-    - magnitude_of_vertical_pressure_velocity_of_cloud_ice_due_to_sedimentation
-    - magnitude_of_vertical_pressure_velocity_of_cloud_liquid_water_due_to_sedimentation
-    - ocean_area_fraction_from_coupler
-    - sea_ice_area_fraction_from_coupler
-    - smoothed_land_area_fraction
-    - stratiform_lwe_cloud_ice_surface_flux_due_to_sedimentation
-    - stratiform_rain_flux_at_surface_due_to_sedimentation
-    - tendency_of_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
-    - tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
-    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
-    - tunable_parameter_for_autoconversion_of_cold_ice_for_rk_microphysics
-    - tunable_parameter_for_ice_fall_velocity_for_rk_microphysics
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/rasch_kristjansson/rk_stratiform.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - cloud_area_fraction
-    - cloud_water_mixing_ratio_wrt_moist_air_and_condensed_water_on_previous_timestep
-    - deep_convective_cloud_area_fraction
-    - detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_all_convection
-    - freezing_point_of_water
-    - land_area_fraction_from_coupler
-    - latent_heat_of_fusion_of_water_at_0c
-    - lwe_large_scale_precipitation_rate_at_surface
-    - lwe_snow_and_cloud_ice_precipitation_rate_at_surface_due_to_microphysics
-    - lwe_snow_precipitation_rate_at_surface_due_to_microphysics
-    - lwe_stratiform_precipitation_rate_at_surface
-    - lwe_surface_snow_depth_over_land_from_coupler
-    - mass_fraction_of_ice_content_within_stratiform_cloud
-    - net_condensation_rate_due_to_microphysics
-    - ocean_area_fraction_from_coupler
-    - rate_of_condensation_minus_evaporation_for_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
-    - rate_of_condensation_minus_evaporation_for_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
-    - rate_of_evaporation_of_precipitation_due_to_microphysics
-    - ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
-    - reference_temperature_lapse_rate
-    - relative_humidity_divided_by_cloud_area_fraction_perturbation
-    - relative_humidity_threshold_for_cloud_formation
-    - sea_ice_area_fraction_from_coupler
-    - sea_surface_temperature_from_coupler
-    - shallow_convective_cloud_area_fraction
-    - smoothed_land_area_fraction
-    - stratiform_cloud_water_surface_flux_due_to_sedimentation
-    - stratiform_lwe_cloud_ice_surface_flux_due_to_sedimentation
-    - stratiform_rain_flux_at_surface_due_to_sedimentation
-    - surface_air_pressure
-    - tendency_of_air_temperature_not_due_to_microphysics
-    - tendency_of_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water
-    - tendency_of_cloud_ice_mixing_ratio_wrt_to_moist_air_and_condensed_water_due_to_ice_to_snow_autoconversion
-    - tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
-    - tendency_of_cloud_liquid_water_mixing_ratio_wrt_to_moist_air_and_condensed_water_due_to_liquid_to_rain_autoconversion
-    - tendency_of_cloud_water_mixing_ratio_wrt_moist_air_and_condensed_water_not_due_to_microphysics
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_cloud_ice_and_cloud_liquid_repartitioning
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_condensation_minus_evaporation
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_evaporation_of_precipitation
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_freezing_of_precipitation
-    - tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_snow_melt
-    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
-    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_not_due_to_microphysics
-    - vertical_layer_index_of_cloud_fraction_top
-    - vertically_integrated_cloud_liquid_water_tendency_due_to_all_convection_to_be_applied_later_in_time_loop
-    - water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_on_previous_timestep
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/thermo_water_update/thermo_water_update.meta
-
+    - ccpp_constituent_properties
     - ccpp_constituents
+    - ccpp_error_code
+    - ccpp_error_message
+    - is_moist_basis_dycore
+    - ln_air_pressure_at_interface
+    - number_of_ccpp_constituents
+    - surface_air_pressure
+    - total_ice_water_mixing_ratio_wrt_moist_air_and_condensed_water_before_physics
+    - total_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water_before_physics
+    - water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_before_physics
+
+--------------------------
+
+atmospheric_physics/schemes/conservation_adjust/check_energy/check_energy_save_teout.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - vertically_integrated_total_energy_using_dycore_energy_formula
+    - vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
+
+--------------------------
+
+atmospheric_physics/schemes/conservation_adjust/check_energy/check_energy_chng.meta
+
+    - air_pressure_of_dry_air_at_interface
+    - air_temperature_at_start_of_physics_timestep
+    - ccpp_constituents
+    - ccpp_error_code
+    - ccpp_error_message
+    - cumulative_total_energy_boundary_flux_using_physics_energy_formula
+    - cumulative_total_water_boundary_flux
+    - flag_for_energy_conservation_warning
+    - geopotential_height_wrt_surface_at_start_of_physics_timestep
+    - latent_heat_of_fusion_of_water_at_0c
+    - net_liquid_and_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
+    - net_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
+    - net_sensible_heat_flux_through_top_and_bottom_of_atmosphere_column
+    - net_water_vapor_fluxes_through_top_and_bottom_of_atmosphere_column
+    - number_of_atmosphere_columns_with_significant_energy_or_water_imbalances
+    - number_of_ccpp_constituents
+    - ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
+    - scheme_name
     - specific_heat_of_air_used_in_dycore
     - total_energy_formula_for_dycore
+    - total_energy_formula_for_physics
+    - vertically_integrated_total_energy_using_dycore_energy_formula
+    - vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
+    - vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
+    - vertically_integrated_total_energy_using_physics_energy_formula
+    - vertically_integrated_total_energy_using_physics_energy_formula_at_start_of_physics_timestep
+    - vertically_integrated_total_water
+    - vertically_integrated_total_water_at_start_of_physics_timestep
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/tj2016/tj2016_sfc_pbl_hs.meta
+atmospheric_physics/schemes/conservation_adjust/check_energy/check_energy_zero_fluxes.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - net_liquid_and_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
+    - net_lwe_ice_fluxes_through_top_and_bottom_of_atmosphere_column
+    - net_sensible_heat_flux_through_top_and_bottom_of_atmosphere_column
+    - net_water_vapor_fluxes_through_top_and_bottom_of_atmosphere_column
+    - scheme_name
+
+--------------------------
+
+atmospheric_physics/schemes/conservation_adjust/check_energy/dycore_energy_consistency_adjust.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - flag_for_dycore_energy_consistency_adjustment
+    - ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
+
+--------------------------
+
+atmospheric_physics/schemes/conservation_adjust/check_energy/check_energy_scaling.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
+    - specific_heat_of_air_used_in_dycore
+
+--------------------------
+
+atmospheric_physics/schemes/conservation_adjust/check_energy/check_energy_fix.meta
 
     - air_pressure_at_interface
     - ccpp_error_code
     - ccpp_error_message
-    - eddy_heat_diffusivity
-    - eddy_momentum_diffusivity
-    - gas_constant_of_water_vapor
-    - ln_air_pressure_at_interface
-    - pi_constant
-    - ratio_of_water_vapor_to_dry_air_molecular_weights
+    - global_mean_heating_rate_correction_for_energy_conservation
+    - net_sensible_heat_flux_through_top_and_bottom_of_atmosphere_column
     - scheme_name
-    - sea_surface_temperature_from_coupler
-    - sum_of_sigma_pressure_hybrid_coordinate_a_coefficient_and_sigma_pressure_hybrid_coordinate_b_coefficient
-    - surface_air_pressure
-    - surface_eastward_wind_stress
-    - surface_evaporation_rate
-    - surface_northward_wind_stress
-    - surface_upward_sensible_heat_flux
-    - tendency_of_air_temperature_due_to_diabatic_heating
-    - tendency_of_air_temperature_due_to_vertical_diffusion
-    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_due_to_vertical_diffusion
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/tj2016/tj2016_precip.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - gas_constant_of_water_vapor
-    - lwe_large_scale_precipitation_rate_at_surface
-    - ratio_of_water_vapor_to_dry_air_molecular_weights
-    - scheme_name
-    - sum_of_sigma_pressure_hybrid_coordinate_a_coefficient_and_sigma_pressure_hybrid_coordinate_b_coefficient
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/musica/musica_ccpp.meta
-
-    - blackbody_temperature_at_surface
-    - ccpp_constituent_properties
-    - ccpp_constituents
-    - ccpp_error_code
-    - ccpp_error_message
-    - cloud_area_fraction
-    - dynamic_constituents_for_musica_ccpp
-    - earth_sun_distance
-    - extraterrestrial_radiation_flux
-    - geopotential_height_wrt_surface_at_interface
-    - molecular_weight_of_dry_air
-    - photolysis_wavelength_grid_interfaces
-    - solar_zenith_angle
-    - surface_albedo_due_to_UV_and_VIS_direct
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/dry_adiabatic_adjust/dadadj.meta
+atmospheric_physics/schemes/conservation_adjust/check_energy/check_energy_gmean/check_energy_gmean.meta
 
     - air_pressure_at_interface
-    - binary_indicator_for_dry_adiabatic_adjusted_grid_cell
     - ccpp_error_code
     - ccpp_error_message
-    - number_of_iterations_for_dry_adiabatic_adjustment_algorithm_convergence
-    - number_of_vertical_levels_from_model_top_where_dry_adiabatic_adjustment_occurs
-    - scheme_name
-    - tendency_of_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+    - global_mean_air_pressure_at_top_of_atmosphere_model
+    - global_mean_heating_rate_correction_for_energy_conservation
+    - global_mean_surface_air_pressure
+    - global_mean_total_energy_correction_for_energy_conservation
+    - global_mean_vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
+    - global_mean_vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
+    - vertically_integrated_total_energy_using_dycore_energy_formula_at_end_of_physics_timestep
+    - vertically_integrated_total_energy_using_dycore_energy_formula_at_start_of_physics_timestep
 
 --------------------------
 
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/rayleigh_friction/rayleigh_friction.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-    - center_vertical_layer_for_rayleigh_friction
-    - model_top_decay_time_for_rayleigh_friction
-    - number_of_vertical_layers_for_rayleigh_friction
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/utilities/static_energy.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/utilities/physics_tendency_updaters.meta
-
-    - ccpp_constituent_tendencies
-    - ccpp_constituents
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/utilities/to_be_ccppized_temporary.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/utilities/qneg.meta
-
-    - ccpp_constituent_minimum_values
-    - ccpp_constituent_properties
-    - ccpp_constituents
-    - ccpp_error_code
-    - ccpp_error_message
-    - number_of_ccpp_constituents
-    - scheme_name
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/utilities/geopotential_temp.meta
-
-    - air_pressure_at_interface
-    - ccpp_constituent_properties
-    - ccpp_constituents
-    - ccpp_error_code
-    - ccpp_error_message
-    - geopotential_height_wrt_surface_at_interface
-    - ln_air_pressure_at_interface
-    - number_of_ccpp_constituents
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/utilities/state_converters.meta
-
-    - ccpp_error_code
-    - ccpp_error_message
-
---------------------------
-
-/glade/u/home/cacraig/cam_sima_caminout/src/physics/ncar_ccpp/schemes/tropopause_find/tropopause_find.meta
+atmospheric_physics/schemes/tropopause_find/tropopause_find.meta
 
     - air_pressure_at_interface
     - ccpp_error_code
@@ -1128,5 +1075,58 @@ Non-dictionary standard names found in the following metadata files:
     - tropopause_vertical_layer_index_from_lapse_rate_method
     - vertical_layer_index_lower_bound_from_hybrid_stobie_linoz_with_climatological_backup_method_for_linearized_ozone_chemistry
     - vertical_layer_index_lower_bound_from_hybrid_stobie_linoz_with_climatological_backup_method_for_stratospheric_chemistry
+
+--------------------------
+
+atmospheric_physics/schemes/held_suarez/held_suarez_1994.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - scheme_name
+
+--------------------------
+
+atmospheric_physics/schemes/rayleigh_friction/rayleigh_friction.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - center_vertical_layer_for_rayleigh_friction
+    - model_top_decay_time_for_rayleigh_friction
+    - number_of_vertical_layers_for_rayleigh_friction
+
+--------------------------
+
+atmospheric_physics/schemes/musica/musica_ccpp.meta
+
+    - blackbody_temperature_at_surface
+    - ccpp_constituent_properties
+    - ccpp_constituents
+    - ccpp_error_code
+    - ccpp_error_message
+    - cloud_area_fraction
+    - dynamic_constituents_for_musica_ccpp
+    - earth_sun_distance
+    - extraterrestrial_radiation_flux
+    - geopotential_height_wrt_surface_at_interface
+    - molecular_weight_of_dry_air
+    - photolysis_wavelength_grid_interfaces
+    - solar_zenith_angle
+    - surface_albedo_due_to_UV_and_VIS_direct
+
+--------------------------
+
+atmospheric_physics/test/test_schemes/file_io_test.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - filename_of_rrtmgp_shortwave_coefficients
+
+--------------------------
+
+atmospheric_physics/test/test_schemes/initialize_constituents.meta
+
+    - ccpp_error_code
+    - ccpp_error_message
+    - dynamic_constituents_for_initialize_constituents
 
 #######################

--- a/schemes/hack_shallow/hack_convect_shallow.meta
+++ b/schemes/hack_shallow/hack_convect_shallow.meta
@@ -251,7 +251,7 @@
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
   intent = out
 [ cmflq ]
-  standard_name = total_water_flux_due_to_shallow_convection
+  standard_name = latent_heat_of_vaporization_times_sum_of_water_vapor_and_cloud_liquid_flux_due_to_shallow_convection
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)

--- a/schemes/sima_diagnostics/convect_shallow_diagnostics.F90
+++ b/schemes/sima_diagnostics/convect_shallow_diagnostics.F90
@@ -48,7 +48,7 @@ contains
     call history_add_field('ICWMRSH', 'in_cloud_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_due_to_shallow_convection', 'lev', 'avg', 'kg kg-1') ! Shallow Convection in-cloud water mixing ratio
 
     call history_add_field('CMFSL', 'liquid_water_static_energy_flux_due_to_shallow_convection', 'ilev', 'avg', 'W m-2') ! Moist shallow convection liquid water static energy flux
-    call history_add_field('CMFLQ', 'total_water_flux_due_to_shallow_convection', 'ilev', 'avg', 'W m-2') ! Moist shallow convection total water flux
+    call history_add_field('CMFLQ', 'latent_heat_of_vaporization_times_sum_of_water_vapor_and_cloud_liquid_flux_due_to_shallow_convection', 'ilev', 'avg', 'W m-2') ! Moist shallow convection total water flux
 
     call history_add_field('FREQSH', 'frequency_of_shallow_convection', horiz_only, 'avg', 'fraction') ! Fractional occurence of shallow convection
 

--- a/schemes/sima_diagnostics/convect_shallow_diagnostics.meta
+++ b/schemes/sima_diagnostics/convect_shallow_diagnostics.meta
@@ -92,7 +92,7 @@
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
   intent = in
 [ cmflq ]
-  standard_name = total_water_flux_due_to_shallow_convection
+  standard_name = latent_heat_of_vaporization_times_sum_of_water_vapor_and_cloud_liquid_flux_due_to_shallow_convection
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)


### PR DESCRIPTION
Originator(s): jimmielin

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- minor update to convect_shallow standard names to match CCPP standard names spreadsheet's approved names

List all namelist files that were added or changed: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M       schemes/hack_shallow/hack_convect_shallow.meta
M       schemes/sima_diagnostics/convect_shallow_diagnostics.F90
M       schemes/sima_diagnostics/convect_shallow_diagnostics.meta
  update convect_shallow standard names

List all automated tests that failed, as well as an explanation for why they weren't fixed: N/A

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? No - metadata only

If yes to the above question, describe how this code was validated with the new/modified features: N/A
