### PR TITLE
Change file reader class allocation methods

### DIFF
--- a/phys_utils/ccpp_io_reader.F90
+++ b/phys_utils/ccpp_io_reader.F90
@@ -12,57 +12,33 @@ module ccpp_io_reader
 
         !Integer interfaces
         procedure(get_var_int_0d),   deferred :: get_var_int_0d
-        procedure(reset_var_int_0d), deferred :: reset_var_int_0d
         procedure(get_var_int_1d),   deferred :: get_var_int_1d
-        procedure(reset_var_int_1d), deferred :: reset_var_int_1d
         procedure(get_var_int_2d),   deferred :: get_var_int_2d
-        procedure(reset_var_int_2d), deferred :: reset_var_int_2d
         procedure(get_var_int_3d),   deferred :: get_var_int_3d
-        procedure(reset_var_int_3d), deferred :: reset_var_int_3d
         procedure(get_var_int_4d),   deferred :: get_var_int_4d
-        procedure(reset_var_int_4d), deferred :: reset_var_int_4d
         procedure(get_var_int_5d),   deferred :: get_var_int_5d
-        procedure(reset_var_int_5d), deferred :: reset_var_int_5d
 
         !Real interfaces
         procedure(get_var_real_0d),   deferred :: get_var_real_0d
-        procedure(reset_var_real_0d), deferred :: reset_var_real_0d
         procedure(get_var_real_1d),   deferred :: get_var_real_1d
-        procedure(reset_var_real_1d), deferred :: reset_var_real_1d
         procedure(get_var_real_2d),   deferred :: get_var_real_2d
-        procedure(reset_var_real_2d), deferred :: reset_var_real_2d
         procedure(get_var_real_3d),   deferred :: get_var_real_3d
-        procedure(reset_var_real_3d), deferred :: reset_var_real_3d
         procedure(get_var_real_4d),   deferred :: get_var_real_4d
-        procedure(reset_var_real_4d), deferred :: reset_var_real_4d
         procedure(get_var_real_5d),   deferred :: get_var_real_5d
-        procedure(reset_var_real_5d), deferred :: reset_var_real_5d
 
         !Character interfaces
         procedure(get_var_char_0d),   deferred :: get_var_char_0d
-        procedure(reset_var_char_0d), deferred :: reset_var_char_0d
         procedure(get_var_char_1d),   deferred :: get_var_char_1d
-        procedure(reset_var_char_1d), deferred :: reset_var_char_1d
         procedure(get_var_char_2d),   deferred :: get_var_char_2d
-        procedure(reset_var_char_2d), deferred :: reset_var_char_2d
         procedure(get_var_char_3d),   deferred :: get_var_char_3d
-        procedure(reset_var_char_3d), deferred :: reset_var_char_3d
         procedure(get_var_char_4d),   deferred :: get_var_char_4d
-        procedure(reset_var_char_4d), deferred :: reset_var_char_4d
         procedure(get_var_char_5d),   deferred :: get_var_char_5d
-        procedure(reset_var_char_5d), deferred :: reset_var_char_5d
 
-        !Generic interface to routines that allocate or associate a pointer variable with data from
+        !Generic interface to routines that allocates a variable with data from
         !an opened NetCDF file variable.
         generic :: get_var => get_var_int_0d, get_var_int_1d, get_var_int_2d, get_var_int_3d, get_var_int_4d, get_var_int_5d, &
-                get_var_real_0d, get_var_real_1d, get_var_real_2d, get_var_real_3d, get_var_real_4d, get_var_real_5d,         &
-                get_var_char_0d, get_var_char_1d, get_var_char_2d, get_var_char_3d, get_var_char_4d, get_var_char_5d
-
-        !Generic interface to routines that "reset", i.e. deallocate and/or nullify, a pointer variable used by "get_var".
-        generic :: reset_var => reset_var_int_0d, reset_var_int_1d, reset_var_int_2d, reset_var_int_3d, reset_var_int_4d,    &
-            reset_var_int_5d, reset_var_real_0d, reset_var_real_1d, reset_var_real_2d, reset_var_real_3d, reset_var_real_4d, &
-            reset_var_real_5d, reset_var_char_0d, reset_var_char_1d, reset_var_char_2d, reset_var_char_3d, reset_var_char_4d, &
-            reset_var_char_5d
+                              get_var_real_0d, get_var_real_1d, get_var_real_2d, get_var_real_3d, get_var_real_4d, get_var_real_5d,         &
+                              get_var_char_0d, get_var_char_1d, get_var_char_2d, get_var_char_3d, get_var_char_4d, get_var_char_5d
     end type abstract_netcdf_reader_t
 
     interface
@@ -91,511 +67,271 @@ module ccpp_io_reader
         ! Integer interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_int_0d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_int_0d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, pointer,                intent(out) :: var     !Integer variable that file data will be read to.
+            integer, allocatable,                intent(out) :: var     !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure.
         end subroutine get_var_int_0d
 
-        subroutine reset_var_int_0d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            integer, pointer,                intent(inout) :: var   !Integer variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg  !Error message
-            integer,                         intent(out) :: errcode !Error code
-        end subroutine reset_var_int_0d
-
-        subroutine get_var_int_1d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_int_1d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, pointer,                intent(out) :: var(:)  !Integer variable that file data will be read to.
+            integer, allocatable,                intent(out) :: var(:)  !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_1d
 
-        subroutine reset_var_int_1d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            integer, pointer,                intent(inout) :: var(:) !Integer variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg   !Error message
-            integer,                         intent(out) :: errcode  !Error code
-        end subroutine reset_var_int_1d
-
-        subroutine get_var_int_2d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_int_2d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, pointer,                intent(out) :: var(:,:)!Integer variable that file data will be read to.
+            integer, allocatable,                intent(out) :: var(:,:)!Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_2d
 
-        subroutine reset_var_int_2d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            integer, pointer,                intent(inout) :: var(:,:) !Integer variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg     !Error message
-            integer,                         intent(out) :: errcode    !Error code
-        end subroutine reset_var_int_2d
-
-        subroutine get_var_int_3d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_int_3d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, pointer,                intent(out) :: var(:,:,:) !Integer variable that file data will be read to.
+            integer, allocatable,                intent(out) :: var(:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_3d
 
-        subroutine reset_var_int_3d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            integer, pointer,                intent(inout) :: var(:,:,:) !Integer variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg       !Error message
-            integer,                         intent(out) :: errcode      !Error code
-        end subroutine reset_var_int_3d
-
-        subroutine get_var_int_4d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_int_4d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, pointer,                intent(out) :: var(:,:,:,:) !Integer variable that file data will be read to.
+            integer, allocatable,                intent(out) :: var(:,:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_4d
 
-        subroutine reset_var_int_4d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            integer, pointer,                intent(inout) :: var(:,:,:,:) !Integer variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg       !Error message
-            integer,                         intent(out) :: errcode      !Error code
-        end subroutine reset_var_int_4d
-
-        subroutine get_var_int_5d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_int_5d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, pointer,                intent(out) :: var(:,:,:,:,:) !Integer variable that file data will be read to.
+            integer, allocatable,                intent(out) :: var(:,:,:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_5d
-
-        subroutine reset_var_int_5d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            integer, pointer,                intent(inout) :: var(:,:,:,:,:) !Integer variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg         !Error message
-            integer,                         intent(out) :: errcode        !Error code
-        end subroutine reset_var_int_5d
 
         ! ------------------------------------------------------------------
         ! Real interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_real_0d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_real_0d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), pointer,        intent(out) :: var     !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,        intent(out) :: var     !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_0d
 
-        subroutine reset_var_real_0d(this, var, errmsg, errcode)
-            use ccpp_kinds, only: kind_phys
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            real(kind_phys), pointer,        intent(inout) :: var   !Floating-point variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg  !Error message
-            integer,                         intent(out) :: errcode !Error code
-        end subroutine reset_var_real_0d
-
-        subroutine get_var_real_1d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_real_1d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), pointer,        intent(out) :: var(:)  !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,        intent(out) :: var(:)  !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_1d
 
-        subroutine reset_var_real_1d(this, var, errmsg, errcode)
-            use ccpp_kinds, only: kind_phys
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            real(kind_phys), pointer,        intent(inout) :: var(:) !Floating-point variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg   !Error message
-            integer,                         intent(out) :: errcode  !Error code
-        end subroutine reset_var_real_1d
-
-        subroutine get_var_real_2d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_real_2d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), pointer,        intent(out) :: var(:,:)!Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,        intent(out) :: var(:,:)!Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_2d
 
-        subroutine reset_var_real_2d(this, var, errmsg, errcode)
-            use ccpp_kinds, only: kind_phys
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            real(kind_phys), pointer,        intent(inout) :: var(:,:) !Floating-point variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg     !Error message
-            integer,                         intent(out) :: errcode    !Error code
-        end subroutine reset_var_real_2d
-
-        subroutine get_var_real_3d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_real_3d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), pointer,        intent(out) :: var(:,:,:) !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,        intent(out) :: var(:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_3d
 
-        subroutine reset_var_real_3d(this, var, errmsg, errcode)
-            use ccpp_kinds, only: kind_phys
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            real(kind_phys), pointer,        intent(inout) :: var(:,:,:) !Floating-point variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg       !Error message
-            integer,                         intent(out) :: errcode      !Error code
-        end subroutine reset_var_real_3d
-
-        subroutine get_var_real_4d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_real_4d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), pointer,        intent(out) :: var(:,:,:,:) !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,        intent(out) :: var(:,:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_4d
 
-        subroutine reset_var_real_4d(this, var, errmsg, errcode)
-            use ccpp_kinds, only: kind_phys
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            real(kind_phys), pointer,        intent(inout) :: var(:,:,:,:) !Floating-point variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg         !Error message
-            integer,                         intent(out) :: errcode        !Error code
-        end subroutine reset_var_real_4d
-
-        subroutine get_var_real_5d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_real_5d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), pointer,        intent(out) :: var(:,:,:,:,:) !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,        intent(out) :: var(:,:,:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_5d
-
-        subroutine reset_var_real_5d(this, var, errmsg, errcode)
-            use ccpp_kinds, only: kind_phys
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            real(kind_phys), pointer,        intent(inout) :: var(:,:,:,:,:) !Floating-point variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg           !Error message
-            integer,                         intent(out) :: errcode          !Error code
-        end subroutine reset_var_real_5d
 
         ! ------------------------------------------------------------------
         ! Character interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_char_0d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_char_0d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), pointer,       intent(out) :: var     !Character variable that file data will be read to.
+            character(len=:), allocatable,       intent(out) :: var     !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_0d
 
-        subroutine reset_var_char_0d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            character(len=:), pointer,       intent(inout) :: var   !Character variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg  !Error message
-            integer,                         intent(out) :: errcode !Error code
-        end subroutine reset_var_char_0d
-
-        subroutine get_var_char_1d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_char_1d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), pointer,       intent(out) :: var(:)  !Character variable that file data will be read to.
+            character(len=:), allocatable,       intent(out) :: var(:)  !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_1d
 
-        subroutine reset_var_char_1d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            character(len=:), pointer,       intent(inout) :: var(:) !Character variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg   !Error message
-            integer,                         intent(out) :: errcode  !Error code
-        end subroutine reset_var_char_1d
-
-        subroutine get_var_char_2d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_char_2d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), pointer,       intent(out) :: var(:,:)!Character variable that file data will be read to.
+            character(len=:), allocatable,       intent(out) :: var(:,:)!Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_2d
 
-        subroutine reset_var_char_2d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            character(len=:), pointer,       intent(inout) :: var(:,:) !Character variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg     !Error message
-            integer,                         intent(out) :: errcode    !Error code
-        end subroutine reset_var_char_2d
-
-        subroutine get_var_char_3d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_char_3d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), pointer,       intent(out) :: var(:,:,:) !Character variable that file data will be read to.
+            character(len=:), allocatable,       intent(out) :: var(:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_3d
 
-        subroutine reset_var_char_3d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            character(len=:), pointer,       intent(inout) :: var(:,:,:) !Character variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg       !Error message
-            integer,                         intent(out) :: errcode      !Error code
-        end subroutine reset_var_char_3d
-
-        subroutine get_var_char_4d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_char_4d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), pointer,       intent(out) :: var(:,:,:,:) !Character variable that file data will be read to.
+            character(len=:), allocatable,       intent(out) :: var(:,:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_4d
 
-        subroutine reset_var_char_4d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            character(len=:), pointer,       intent(inout) :: var(:,:,:,:) !Character variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg         !Error message
-            integer,                         intent(out) :: errcode        !Error code
-        end subroutine reset_var_char_4d
-
-        subroutine get_var_char_5d(this, varname, var, errmsg, errcode, start, count, local_alloc)
+        subroutine get_var_char_5d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), pointer,       intent(out) :: var(:,:,:,:,:) !Character variable that file data will be read to.
+            character(len=:), allocatable,       intent(out) :: var(:,:,:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
 
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
-
-            !Optional argument to control local allocation of the variable
-            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
-                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_5d
-
-        subroutine reset_var_char_5d(this, var, errmsg, errcode)
-            import abstract_netcdf_reader_t
-
-            class(abstract_netcdf_reader_t), intent(in)  :: this
-            character(len=:), pointer,       intent(inout) :: var(:,:,:,:,:) !Character variable that will be "reset".
-            character(len=*),                intent(out) :: errmsg           !Error message
-            integer,                         intent(out) :: errcode          !Error code
-        end subroutine reset_var_char_5d
 
     end interface
 

--- a/phys_utils/ccpp_io_reader.F90
+++ b/phys_utils/ccpp_io_reader.F90
@@ -72,7 +72,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, allocatable,                intent(out) :: var     !Integer variable that file data will be read to.
+            integer, allocatable,            intent(out) :: var     !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -86,7 +86,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, allocatable,                intent(out) :: var(:)  !Integer variable that file data will be read to.
+            integer, allocatable,            intent(out) :: var(:)  !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -100,7 +100,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, allocatable,                intent(out) :: var(:,:)!Integer variable that file data will be read to.
+            integer, allocatable,            intent(out) :: var(:,:)!Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -114,7 +114,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, allocatable,                intent(out) :: var(:,:,:) !Integer variable that file data will be read to.
+            integer, allocatable,            intent(out) :: var(:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
 
@@ -128,7 +128,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, allocatable,                intent(out) :: var(:,:,:,:) !Integer variable that file data will be read to.
+            integer, allocatable,            intent(out) :: var(:,:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
 
@@ -142,7 +142,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            integer, allocatable,                intent(out) :: var(:,:,:,:,:) !Integer variable that file data will be read to.
+            integer, allocatable,            intent(out) :: var(:,:,:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
 
@@ -161,7 +161,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), allocatable,        intent(out) :: var     !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,    intent(out) :: var     !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -176,7 +176,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), allocatable,        intent(out) :: var(:)  !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,    intent(out) :: var(:)  !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -191,7 +191,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), allocatable,        intent(out) :: var(:,:)!Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,    intent(out) :: var(:,:)!Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -206,7 +206,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), allocatable,        intent(out) :: var(:,:,:) !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,    intent(out) :: var(:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
 
@@ -221,7 +221,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), allocatable,        intent(out) :: var(:,:,:,:) !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,    intent(out) :: var(:,:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
 
@@ -236,7 +236,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            real(kind_phys), allocatable,        intent(out) :: var(:,:,:,:,:) !Floating-point variable that file data will be read to.
+            real(kind_phys), allocatable,    intent(out) :: var(:,:,:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
 
@@ -254,7 +254,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), allocatable,       intent(out) :: var     !Character variable that file data will be read to.
+            character(len=:), allocatable,   intent(out) :: var     !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -268,7 +268,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), allocatable,       intent(out) :: var(:)  !Character variable that file data will be read to.
+            character(len=:), allocatable,   intent(out) :: var(:)  !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -282,7 +282,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), allocatable,       intent(out) :: var(:,:)!Character variable that file data will be read to.
+            character(len=:), allocatable,   intent(out) :: var(:,:)!Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
 
@@ -296,7 +296,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), allocatable,       intent(out) :: var(:,:,:) !Character variable that file data will be read to.
+            character(len=:), allocatable,   intent(out) :: var(:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
 
@@ -310,7 +310,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), allocatable,       intent(out) :: var(:,:,:,:) !Character variable that file data will be read to.
+            character(len=:), allocatable,   intent(out) :: var(:,:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
 
@@ -324,7 +324,7 @@ module ccpp_io_reader
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
             character(len=*),                intent(in)  :: varname
-            character(len=:), allocatable,       intent(out) :: var(:,:,:,:,:) !Character variable that file data will be read to.
+            character(len=:), allocatable,   intent(out) :: var(:,:,:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
 

--- a/phys_utils/ccpp_io_reader.F90
+++ b/phys_utils/ccpp_io_reader.F90
@@ -9,28 +9,60 @@ module ccpp_io_reader
     contains
         procedure(open_file),    deferred :: open_file
         procedure(close_file),   deferred :: close_file
-        procedure(get_var_int_0d),  deferred :: get_var_int_0d
-        procedure(get_var_int_1d),  deferred :: get_var_int_1d
-        procedure(get_var_int_2d),  deferred :: get_var_int_2d
-        procedure(get_var_int_3d),  deferred :: get_var_int_3d
-        procedure(get_var_int_4d),  deferred :: get_var_int_4d
-        procedure(get_var_int_5d),  deferred :: get_var_int_5d
-        procedure(get_var_real_0d), deferred :: get_var_real_0d
-        procedure(get_var_real_1d), deferred :: get_var_real_1d
-        procedure(get_var_real_2d), deferred :: get_var_real_2d
-        procedure(get_var_real_3d), deferred :: get_var_real_3d
-        procedure(get_var_real_4d), deferred :: get_var_real_4d
-        procedure(get_var_real_5d), deferred :: get_var_real_5d
-        procedure(get_var_char_0d), deferred :: get_var_char_0d
-        procedure(get_var_char_1d), deferred :: get_var_char_1d
-        procedure(get_var_char_2d), deferred :: get_var_char_2d
-        procedure(get_var_char_3d), deferred :: get_var_char_3d
-        procedure(get_var_char_4d), deferred :: get_var_char_4d
-        procedure(get_var_char_5d), deferred :: get_var_char_5d
 
+        !Integer interfaces
+        procedure(get_var_int_0d),   deferred :: get_var_int_0d
+        procedure(reset_var_int_0d), deferred :: reset_var_int_0d
+        procedure(get_var_int_1d),   deferred :: get_var_int_1d
+        procedure(reset_var_int_1d), deferred :: reset_var_int_1d
+        procedure(get_var_int_2d),   deferred :: get_var_int_2d
+        procedure(reset_var_int_2d), deferred :: reset_var_int_2d
+        procedure(get_var_int_3d),   deferred :: get_var_int_3d
+        procedure(reset_var_int_3d), deferred :: reset_var_int_3d
+        procedure(get_var_int_4d),   deferred :: get_var_int_4d
+        procedure(reset_var_int_4d), deferred :: reset_var_int_4d
+        procedure(get_var_int_5d),   deferred :: get_var_int_5d
+        procedure(reset_var_int_5d), deferred :: reset_var_int_5d
+
+        !Real interfaces
+        procedure(get_var_real_0d),   deferred :: get_var_real_0d
+        procedure(reset_var_real_0d), deferred :: reset_var_real_0d
+        procedure(get_var_real_1d),   deferred :: get_var_real_1d
+        procedure(reset_var_real_1d), deferred :: reset_var_real_1d
+        procedure(get_var_real_2d),   deferred :: get_var_real_2d
+        procedure(reset_var_real_2d), deferred :: reset_var_real_2d
+        procedure(get_var_real_3d),   deferred :: get_var_real_3d
+        procedure(reset_var_real_3d), deferred :: reset_var_real_3d 
+        procedure(get_var_real_4d),   deferred :: get_var_real_4d
+        procedure(reset_var_real_4d), deferred :: reset_var_real_4d 
+        procedure(get_var_real_5d),   deferred :: get_var_real_5d
+        procedure(reset_var_real_5d), deferred :: reset_var_real_5d
+
+        !Character interfaces
+        procedure(get_var_char_0d),   deferred :: get_var_char_0d
+        procedure(reset_var_char_0d), deferred :: reset_var_char_0d
+        procedure(get_var_char_1d),   deferred :: get_var_char_1d
+        procedure(reset_var_char_1d), deferred :: reset_var_char_1d
+        procedure(get_var_char_2d),   deferred :: get_var_char_2d
+        procedure(reset_var_char_2d), deferred :: reset_var_char_2d
+        procedure(get_var_char_3d),   deferred :: get_var_char_3d
+        procedure(reset_var_char_3d), deferred :: reset_var_char_3d
+        procedure(get_var_char_4d),   deferred :: get_var_char_4d
+        procedure(reset_var_char_4d), deferred :: reset_var_char_4d
+        procedure(get_var_char_5d),   deferred :: get_var_char_5d
+        procedure(reset_var_char_5d), deferred :: reset_var_char_5d
+
+        !Generic interface to routines that allocate or associate a pointer variable with data from
+        !an opened NetCDF file variable.
         generic :: get_var => get_var_int_0d, get_var_int_1d, get_var_int_2d, get_var_int_3d, get_var_int_4d, get_var_int_5d, &
                 get_var_real_0d, get_var_real_1d, get_var_real_2d, get_var_real_3d, get_var_real_4d, get_var_real_5d,         &
                 get_var_char_0d, get_var_char_1d, get_var_char_2d, get_var_char_3d, get_var_char_4d, get_var_char_5d
+ 
+        !Generic interface to routines that "reset", i.e. deallocate and/or nullify, a pointer variable used by "get_var".
+        generic :: reset_var => reset_var_int_0d, reset_var_int_1d, reset_var_int_2d, reset_var_int_3d, reset_var_int_4d,    &
+            reset_var_int_5d, reset_var_real_0d, reset_var_real_1d, reset_var_real_2d, reset_var_real_3d, reset_var_real_4d, &
+            reset_var_real_5d, reset_var_char_0d, reset_var_char_1d, reset_var_char_2d, reset_var_char_3d, reset_var_char_4d, & 
+            reset_var_char_5d
     end type abstract_netcdf_reader_t
 
     interface
@@ -59,7 +91,7 @@ module ccpp_io_reader
         ! Integer interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_int_0d(this, varname, var, errmsg, errcode)
+        subroutine get_var_int_0d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -67,9 +99,22 @@ module ccpp_io_reader
             integer, pointer,                intent(out) :: var     !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_int_0d
 
-        subroutine get_var_int_1d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_int_0d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            integer, pointer,                intent(inout) :: var   !Integer variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg  !Error message
+            integer,                         intent(out) :: errcode !Error code
+        end subroutine reset_var_int_0d
+
+        subroutine get_var_int_1d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -77,9 +122,22 @@ module ccpp_io_reader
             integer, pointer,                intent(out) :: var(:)  !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_int_1d
 
-        subroutine get_var_int_2d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_int_1d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            integer, pointer,                intent(inout) :: var(:) !Integer variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg   !Error message
+            integer,                         intent(out) :: errcode  !Error code
+        end subroutine reset_var_int_1d
+
+        subroutine get_var_int_2d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -87,9 +145,22 @@ module ccpp_io_reader
             integer, pointer,                intent(out) :: var(:,:)!Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_int_2d
 
-        subroutine get_var_int_3d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_int_2d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            integer, pointer,                intent(inout) :: var(:,:) !Integer variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg     !Error message
+            integer,                         intent(out) :: errcode    !Error code
+        end subroutine reset_var_int_2d
+
+        subroutine get_var_int_3d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -97,9 +168,22 @@ module ccpp_io_reader
             integer, pointer,                intent(out) :: var(:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_int_3d
 
-        subroutine get_var_int_4d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_int_3d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            integer, pointer,                intent(inout) :: var(:,:,:) !Integer variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg       !Error message
+            integer,                         intent(out) :: errcode      !Error code
+        end subroutine reset_var_int_3d
+
+        subroutine get_var_int_4d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -107,9 +191,22 @@ module ccpp_io_reader
             integer, pointer,                intent(out) :: var(:,:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_int_4d
 
-        subroutine get_var_int_5d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_int_4d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            integer, pointer,                intent(inout) :: var(:,:,:,:) !Integer variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg       !Error message
+            integer,                         intent(out) :: errcode      !Error code
+        end subroutine reset_var_int_4d
+
+        subroutine get_var_int_5d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -117,13 +214,26 @@ module ccpp_io_reader
             integer, pointer,                intent(out) :: var(:,:,:,:,:) !Integer variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_int_5d
+
+        subroutine reset_var_int_5d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            integer, pointer,                intent(inout) :: var(:,:,:,:,:) !Integer variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg         !Error message
+            integer,                         intent(out) :: errcode        !Error code
+        end subroutine reset_var_int_5d
 
         ! ------------------------------------------------------------------
         ! Real interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_real_0d(this, varname, var, errmsg, errcode)
+        subroutine get_var_real_0d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -132,9 +242,23 @@ module ccpp_io_reader
             real(kind_phys), pointer,        intent(out) :: var     !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_real_0d
 
-        subroutine get_var_real_1d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_real_0d(this, var, errmsg, errcode)
+            use ccpp_kinds, only: kind_phys
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            real(kind_phys), pointer,        intent(inout) :: var   !Floating-point variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg  !Error message
+            integer,                         intent(out) :: errcode !Error code
+        end subroutine reset_var_real_0d
+
+        subroutine get_var_real_1d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -143,9 +267,23 @@ module ccpp_io_reader
             real(kind_phys), pointer,        intent(out) :: var(:)  !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_real_1d
 
-        subroutine get_var_real_2d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_real_1d(this, var, errmsg, errcode)
+            use ccpp_kinds, only: kind_phys
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            real(kind_phys), pointer,        intent(inout) :: var(:) !Floating-point variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg   !Error message
+            integer,                         intent(out) :: errcode  !Error code
+        end subroutine reset_var_real_1d
+
+        subroutine get_var_real_2d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -154,9 +292,23 @@ module ccpp_io_reader
             real(kind_phys), pointer,        intent(out) :: var(:,:)!Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_real_2d
 
-        subroutine get_var_real_3d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_real_2d(this, var, errmsg, errcode)
+            use ccpp_kinds, only: kind_phys
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            real(kind_phys), pointer,        intent(inout) :: var(:,:) !Floating-point variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg     !Error message
+            integer,                         intent(out) :: errcode    !Error code
+        end subroutine reset_var_real_2d
+
+        subroutine get_var_real_3d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -165,9 +317,23 @@ module ccpp_io_reader
             real(kind_phys), pointer,        intent(out) :: var(:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_real_3d
 
-        subroutine get_var_real_4d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_real_3d(this, var, errmsg, errcode)
+            use ccpp_kinds, only: kind_phys
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            real(kind_phys), pointer,        intent(inout) :: var(:,:,:) !Floating-point variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg       !Error message
+            integer,                         intent(out) :: errcode      !Error code
+        end subroutine reset_var_real_3d
+
+        subroutine get_var_real_4d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -176,9 +342,23 @@ module ccpp_io_reader
             real(kind_phys), pointer,        intent(out) :: var(:,:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_real_4d
 
-        subroutine get_var_real_5d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_real_4d(this, var, errmsg, errcode)
+            use ccpp_kinds, only: kind_phys
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            real(kind_phys), pointer,        intent(inout) :: var(:,:,:,:) !Floating-point variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg         !Error message
+            integer,                         intent(out) :: errcode        !Error code
+        end subroutine reset_var_real_4d
+
+        subroutine get_var_real_5d(this, varname, var, errmsg, errcode, start, count)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -187,13 +367,27 @@ module ccpp_io_reader
             real(kind_phys), pointer,        intent(out) :: var(:,:,:,:,:) !Floating-point variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_real_5d
+
+        subroutine reset_var_real_5d(this, var, errmsg, errcode)
+            use ccpp_kinds, only: kind_phys
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            real(kind_phys), pointer,        intent(inout) :: var(:,:,:,:,:) !Floating-point variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg           !Error message
+            integer,                         intent(out) :: errcode          !Error code
+        end subroutine reset_var_real_5d
 
         ! ------------------------------------------------------------------
         ! Character interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_char_0d(this, varname, var, errmsg, errcode)
+        subroutine get_var_char_0d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -201,9 +395,22 @@ module ccpp_io_reader
             character(len=:), pointer,       intent(out) :: var     !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_char_0d
 
-        subroutine get_var_char_1d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_char_0d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            character(len=:), pointer,       intent(inout) :: var   !Character variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg  !Error message
+            integer,                         intent(out) :: errcode !Error code
+        end subroutine reset_var_char_0d
+
+        subroutine get_var_char_1d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -211,9 +418,22 @@ module ccpp_io_reader
             character(len=:), pointer,       intent(out) :: var(:)  !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_char_1d
 
-        subroutine get_var_char_2d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_char_1d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            character(len=:), pointer,       intent(inout) :: var(:) !Character variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg   !Error message
+            integer,                         intent(out) :: errcode  !Error code
+        end subroutine reset_var_char_1d
+
+        subroutine get_var_char_2d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -221,9 +441,22 @@ module ccpp_io_reader
             character(len=:), pointer,       intent(out) :: var(:,:)!Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg  !Error message
             integer,                         intent(out) :: errcode !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_char_2d
 
-        subroutine get_var_char_3d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_char_2d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            character(len=:), pointer,       intent(inout) :: var(:,:) !Character variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg     !Error message
+            integer,                         intent(out) :: errcode    !Error code
+        end subroutine reset_var_char_2d
+
+        subroutine get_var_char_3d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -231,9 +464,22 @@ module ccpp_io_reader
             character(len=:), pointer,       intent(out) :: var(:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg     !Error message
             integer,                         intent(out) :: errcode    !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_char_3d
 
-        subroutine get_var_char_4d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_char_3d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            character(len=:), pointer,       intent(inout) :: var(:,:,:) !Character variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg       !Error message
+            integer,                         intent(out) :: errcode      !Error code
+        end subroutine reset_var_char_3d
+
+        subroutine get_var_char_4d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -241,9 +487,22 @@ module ccpp_io_reader
             character(len=:), pointer,       intent(out) :: var(:,:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg       !Error message
             integer,                         intent(out) :: errcode      !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_char_4d
 
-        subroutine get_var_char_5d(this, varname, var, errmsg, errcode)
+        subroutine reset_var_char_4d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            character(len=:), pointer,       intent(inout) :: var(:,:,:,:) !Character variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg         !Error message
+            integer,                         intent(out) :: errcode        !Error code
+        end subroutine reset_var_char_4d
+
+        subroutine get_var_char_5d(this, varname, var, errmsg, errcode, start, count)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -251,7 +510,20 @@ module ccpp_io_reader
             character(len=:), pointer,       intent(out) :: var(:,:,:,:,:) !Character variable that file data will be read to.
             character(len=*),                intent(out) :: errmsg         !Error message
             integer,                         intent(out) :: errcode        !Error code
+
+            !Optional arguments for reading a subset of the variable
+            integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
+            integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
         end subroutine get_var_char_5d
+
+        subroutine reset_var_char_5d(this, var, errmsg, errcode)
+            import abstract_netcdf_reader_t
+
+            class(abstract_netcdf_reader_t), intent(in)  :: this
+            character(len=:), pointer,       intent(inout) :: var(:,:,:,:,:) !Character variable that will be "reset".
+            character(len=*),                intent(out) :: errmsg           !Error message
+            integer,                         intent(out) :: errcode          !Error code
+        end subroutine reset_var_char_5d
 
     end interface
 

--- a/phys_utils/ccpp_io_reader.F90
+++ b/phys_utils/ccpp_io_reader.F90
@@ -32,9 +32,9 @@ module ccpp_io_reader
         procedure(get_var_real_2d),   deferred :: get_var_real_2d
         procedure(reset_var_real_2d), deferred :: reset_var_real_2d
         procedure(get_var_real_3d),   deferred :: get_var_real_3d
-        procedure(reset_var_real_3d), deferred :: reset_var_real_3d 
+        procedure(reset_var_real_3d), deferred :: reset_var_real_3d
         procedure(get_var_real_4d),   deferred :: get_var_real_4d
-        procedure(reset_var_real_4d), deferred :: reset_var_real_4d 
+        procedure(reset_var_real_4d), deferred :: reset_var_real_4d
         procedure(get_var_real_5d),   deferred :: get_var_real_5d
         procedure(reset_var_real_5d), deferred :: reset_var_real_5d
 
@@ -57,11 +57,11 @@ module ccpp_io_reader
         generic :: get_var => get_var_int_0d, get_var_int_1d, get_var_int_2d, get_var_int_3d, get_var_int_4d, get_var_int_5d, &
                 get_var_real_0d, get_var_real_1d, get_var_real_2d, get_var_real_3d, get_var_real_4d, get_var_real_5d,         &
                 get_var_char_0d, get_var_char_1d, get_var_char_2d, get_var_char_3d, get_var_char_4d, get_var_char_5d
- 
+
         !Generic interface to routines that "reset", i.e. deallocate and/or nullify, a pointer variable used by "get_var".
         generic :: reset_var => reset_var_int_0d, reset_var_int_1d, reset_var_int_2d, reset_var_int_3d, reset_var_int_4d,    &
             reset_var_int_5d, reset_var_real_0d, reset_var_real_1d, reset_var_real_2d, reset_var_real_3d, reset_var_real_4d, &
-            reset_var_real_5d, reset_var_char_0d, reset_var_char_1d, reset_var_char_2d, reset_var_char_3d, reset_var_char_4d, & 
+            reset_var_real_5d, reset_var_char_0d, reset_var_char_1d, reset_var_char_2d, reset_var_char_3d, reset_var_char_4d, &
             reset_var_char_5d
     end type abstract_netcdf_reader_t
 
@@ -91,7 +91,7 @@ module ccpp_io_reader
         ! Integer interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_int_0d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_int_0d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -103,6 +103,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure.
         end subroutine get_var_int_0d
 
         subroutine reset_var_int_0d(this, var, errmsg, errcode)
@@ -114,7 +118,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode !Error code
         end subroutine reset_var_int_0d
 
-        subroutine get_var_int_1d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_int_1d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -126,6 +130,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_1d
 
         subroutine reset_var_int_1d(this, var, errmsg, errcode)
@@ -137,7 +145,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode  !Error code
         end subroutine reset_var_int_1d
 
-        subroutine get_var_int_2d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_int_2d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -149,6 +157,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_2d
 
         subroutine reset_var_int_2d(this, var, errmsg, errcode)
@@ -160,7 +172,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode    !Error code
         end subroutine reset_var_int_2d
 
-        subroutine get_var_int_3d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_int_3d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -172,6 +184,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_3d
 
         subroutine reset_var_int_3d(this, var, errmsg, errcode)
@@ -183,7 +199,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode      !Error code
         end subroutine reset_var_int_3d
 
-        subroutine get_var_int_4d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_int_4d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -195,6 +211,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_4d
 
         subroutine reset_var_int_4d(this, var, errmsg, errcode)
@@ -206,7 +226,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode      !Error code
         end subroutine reset_var_int_4d
 
-        subroutine get_var_int_5d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_int_5d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -218,6 +238,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_int_5d
 
         subroutine reset_var_int_5d(this, var, errmsg, errcode)
@@ -233,7 +257,7 @@ module ccpp_io_reader
         ! Real interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_real_0d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_real_0d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -246,6 +270,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_0d
 
         subroutine reset_var_real_0d(this, var, errmsg, errcode)
@@ -258,7 +286,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode !Error code
         end subroutine reset_var_real_0d
 
-        subroutine get_var_real_1d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_real_1d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -271,6 +299,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_1d
 
         subroutine reset_var_real_1d(this, var, errmsg, errcode)
@@ -283,7 +315,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode  !Error code
         end subroutine reset_var_real_1d
 
-        subroutine get_var_real_2d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_real_2d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -296,6 +328,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_2d
 
         subroutine reset_var_real_2d(this, var, errmsg, errcode)
@@ -308,7 +344,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode    !Error code
         end subroutine reset_var_real_2d
 
-        subroutine get_var_real_3d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_real_3d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -321,6 +357,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_3d
 
         subroutine reset_var_real_3d(this, var, errmsg, errcode)
@@ -333,7 +373,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode      !Error code
         end subroutine reset_var_real_3d
 
-        subroutine get_var_real_4d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_real_4d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -346,6 +386,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_4d
 
         subroutine reset_var_real_4d(this, var, errmsg, errcode)
@@ -358,7 +402,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode        !Error code
         end subroutine reset_var_real_4d
 
-        subroutine get_var_real_5d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_real_5d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             use ccpp_kinds, only: kind_phys
             import abstract_netcdf_reader_t
 
@@ -371,6 +415,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_real_5d
 
         subroutine reset_var_real_5d(this, var, errmsg, errcode)
@@ -387,7 +435,7 @@ module ccpp_io_reader
         ! Character interfaces
         ! ------------------------------------------------------------------
 
-        subroutine get_var_char_0d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_char_0d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -399,6 +447,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_0d
 
         subroutine reset_var_char_0d(this, var, errmsg, errcode)
@@ -410,7 +462,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode !Error code
         end subroutine reset_var_char_0d
 
-        subroutine get_var_char_1d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_char_1d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -422,6 +474,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_1d
 
         subroutine reset_var_char_1d(this, var, errmsg, errcode)
@@ -433,7 +489,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode  !Error code
         end subroutine reset_var_char_1d
 
-        subroutine get_var_char_2d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_char_2d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -445,6 +501,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_2d
 
         subroutine reset_var_char_2d(this, var, errmsg, errcode)
@@ -456,7 +516,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode    !Error code
         end subroutine reset_var_char_2d
 
-        subroutine get_var_char_3d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_char_3d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -468,6 +528,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_3d
 
         subroutine reset_var_char_3d(this, var, errmsg, errcode)
@@ -479,7 +543,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode      !Error code
         end subroutine reset_var_char_3d
 
-        subroutine get_var_char_4d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_char_4d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -491,6 +555,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_4d
 
         subroutine reset_var_char_4d(this, var, errmsg, errcode)
@@ -502,7 +570,7 @@ module ccpp_io_reader
             integer,                         intent(out) :: errcode        !Error code
         end subroutine reset_var_char_4d
 
-        subroutine get_var_char_5d(this, varname, var, errmsg, errcode, start, count)
+        subroutine get_var_char_5d(this, varname, var, errmsg, errcode, start, count, local_alloc)
             import abstract_netcdf_reader_t
 
             class(abstract_netcdf_reader_t), intent(in)  :: this
@@ -514,6 +582,10 @@ module ccpp_io_reader
             !Optional arguments for reading a subset of the variable
             integer, optional,               intent(in)  :: start(:) !Start indices for each dimension
             integer, optional,               intent(in)  :: count(:) !Number of elements to read for each dimension
+
+            !Optional argument to control local allocation of the variable
+            logical, optional,               intent(in)  :: local_alloc !If true, the variable will be allocated locally,
+                                                                        !using Fortran's intrinsic "allocate" procedure
         end subroutine get_var_char_5d
 
         subroutine reset_var_char_5d(this, var, errmsg, errcode)

--- a/phys_utils/ccpp_io_reader.F90
+++ b/phys_utils/ccpp_io_reader.F90
@@ -43,7 +43,7 @@ module ccpp_io_reader
 
     interface
         module function create_netcdf_reader_t() result(r)
-            class(abstract_netcdf_reader_t), allocatable :: r
+            class(abstract_netcdf_reader_t), pointer :: r
         end function create_netcdf_reader_t
 
         subroutine open_file(this, file_path, errmsg, errcode)

--- a/test/test_schemes/file_io_test.F90
+++ b/test/test_schemes/file_io_test.F90
@@ -32,9 +32,9 @@ contains
 
      !Variables read from file:
      character(len=:), allocatable :: gas_names(:)
-     integer, allocatable          :: band2gpt(:,:)
-     real(kind_phys), allocatable  :: press_ref(:)
-     real(kind_phys), allocatable  :: band_lims_wavenum(:,:)
+     integer,          allocatable :: band2gpt(:,:)
+     real(kind_phys),  allocatable :: press_ref(:)
+     real(kind_phys),  allocatable :: band_lims_wavenum(:,:)
 
      class(abstract_netcdf_reader_t), allocatable :: reader
 

--- a/test/test_schemes/file_io_test.F90
+++ b/test/test_schemes/file_io_test.F90
@@ -36,13 +36,13 @@ contains
      real(kind_phys),  allocatable :: press_ref(:)
      real(kind_phys),  allocatable :: band_lims_wavenum(:,:)
 
-     class(abstract_netcdf_reader_t), allocatable :: reader
+     class(abstract_netcdf_reader_t), pointer :: reader
 
      !NetCDF dimensions:
      integer :: bnd
      integer :: absorber
 
-     reader = create_netcdf_reader_t()
+     reader => create_netcdf_reader_t()
 
      !Initialize output variables:
      errcode = 0
@@ -100,6 +100,10 @@ contains
      write(*,*) 'Max RRTMGP reference pressure value = ', maxval(press_ref)
      write(*,*) 'Max RRTMGP band starting wave idx   = ', maxval(band2gpt(1,:))
      write(*,*) 'Max RRTMGP band starting wavenumber = ', maxval(band_lims_wavenum(1,:))
+
+     !Reset file reader:
+     deallocate(reader)
+     nullify(reader)
 
   end subroutine file_io_test_init
 

--- a/test/test_schemes/file_io_test.F90
+++ b/test/test_schemes/file_io_test.F90
@@ -31,10 +31,10 @@ contains
      integer,            intent(out) :: errcode
 
      !Variables read from file:
-     character(len=:), pointer :: gas_names(:)
-     integer, pointer          :: band2gpt(:,:)
-     real(kind_phys), pointer  :: press_ref(:)
-     real(kind_phys), pointer  :: band_lims_wavenum(:,:)
+     character(len=:), allocatable :: gas_names(:)
+     integer, allocatable          :: band2gpt(:,:)
+     real(kind_phys), allocatable  :: press_ref(:)
+     real(kind_phys), allocatable  :: band_lims_wavenum(:,:)
 
      class(abstract_netcdf_reader_t), allocatable :: reader
 


### PR DESCRIPTION
Originator(s): nusbaume

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):

@peverwhee discovered during testing of the changes  atmospheric_physics#258 that two changes needed to be made to the NetCDF reader class, specifically:

1.  The constructor must allocate a pointer, not an allocatable variable (due to the fact that allocating a variable via a function doesn't have a Fortran standard-defined order, and so can result in "already allocated" errors).

2.  The CCPP-framework does not currently allow for the passing of pointers, and so all variables allocated by the reader itself during the `get_var` method should be of type `allocatable`, not `pointer`.  Of course if we eventually find that we really do need a pointer option then we can always provide two versions of the class itself for the developer to choose from.

Finally, this PR contains the addition of a `start` and `count` variable to use for file data subsetting.

List all namelist files that were added or changed:

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

M       phys_utils/ccpp_io_reader.F90
   - Change constructor to pointer, get_var to allocatable, and add optional start/count variables

M       test/test_schemes/file_io_test.F90
   - Update test scheme to properly use new file reader class

List all automated tests that failed, as well as an explanation for why they weren't fixed: 

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

If yes to the above question, describe how this code was validated with the new/modified features:
