### PR TITLE
atmos_phys0_16_000: merge development to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,9 @@
 	fxtag = 20240626-MPASv8.2
 	fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/NCAR/MMM-physics.git
+[submodule "pumas"]
+        path = schemes/pumas/pumas
+        url = https://github.com/ESCOMP/PUMAS
+        fxrequired = AlwaysRequired
+        fxtag = pumas_cam-release_v1.39
+        fxDONOTUSEurl = https://github.com/ESCOMP/PUMAS


### PR DESCRIPTION
Tag name (The PR title should also include the tag name): atmos_phys0_16_000
Originator(s): cacraigucar

List all development PR numbers included in this PR and the title of each:
* Move PUMAS to externals in atmospheric_physics (#271)

List all automated tests that failed, as well as an explanation for why they weren't fixed: