### PR TITLE
atmos_phys0_16_001:  Merge development into main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,8 +5,8 @@
 	fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/NCAR/MMM-physics.git
 [submodule "pumas"]
-        path = schemes/pumas/pumas
-        url = https://github.com/ESCOMP/PUMAS
+	path = schemes/pumas/pumas
+	url = https://github.com/ESCOMP/PUMAS
         fxrequired = AlwaysRequired
         fxtag = pumas_cam-release_v1.39
         fxDONOTUSEurl = https://github.com/ESCOMP/PUMAS


### PR DESCRIPTION
Tag name (The PR title should also include the tag name): atmos_phys0_16_001
Originator(s): cacraigucar

List all development PR numbers included in this PR and the title of each:

Update .gitmodules and PUMAS external directory #290 

List all automated tests that failed, as well as an explanation for why they weren't fixed: none