### PR TITLE
Initialize shear squared and Richardson number to zeroes outside of turbulence region in the HB PBL scheme

### DIFF
--- a/schemes/holtslag_boville/holtslag_boville_diff.F90
+++ b/schemes/holtslag_boville/holtslag_boville_diff.F90
@@ -214,6 +214,10 @@ contains
     kbfs(:ncol)   = calc_kinematic_buoyancy_flux(khfs(:ncol), zvir, th(:ncol,pver), kqfs(:ncol))
     obklen(:ncol) = calc_obukhov_length(thv(:ncol,pver), ustar(:ncol), gravit, karman, kbfs(:ncol))
 
+    ! Initialize output arrays outside of turbulence region to zeroes
+    s2(:,:) = 0._kind_phys
+    ri(:,:) = 0._kind_phys
+
     ! Compute s^2 (shear squared), n^2 (brunt vaisaila frequency), and ri (Richardson number = n^2/s^2)
     ! using virtual temperature
     ! (formerly trbintd)


### PR DESCRIPTION
Originator(s): @jimmielin @peverwhee 

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Proposed fix for https://github.com/ESCOMP/CAM-SIMA/issues/429

List all namelist files that were added or changed: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       schemes/holtslag_boville/holtslag_boville_diff.F90
   - fix initialization outside of turbulence region for s2, ri
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?
Uninitialized regions in HB_ri should now be zeroes

If yes to the above question, describe how this code was validated with the new/modified features:
- create test `SMS_D_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_hb_vdiff_derecho` run twice to check consistency
- observe outside of turbulence region (basically just at `pver`) that values are now correctly zero vs. garbage
