### PR TITLE
atmos_phys0_18_001:  Bring in bug fixes and CAM performance improvements. 

### DIFF
--- a/schemes/holtslag_boville/holtslag_boville_diff.F90
+++ b/schemes/holtslag_boville/holtslag_boville_diff.F90
@@ -214,6 +214,10 @@ contains
     kbfs(:ncol)   = calc_kinematic_buoyancy_flux(khfs(:ncol), zvir, th(:ncol,pver), kqfs(:ncol))
     obklen(:ncol) = calc_obukhov_length(thv(:ncol,pver), ustar(:ncol), gravit, karman, kbfs(:ncol))
 
+    ! Initialize output arrays outside of turbulence region to zeroes
+    s2(:,:) = 0._kind_phys
+    ri(:,:) = 0._kind_phys
+
     ! Compute s^2 (shear squared), n^2 (brunt vaisaila frequency), and ri (Richardson number = n^2/s^2)
     ! using virtual temperature
     ! (formerly trbintd)

--- a/schemes/sima_diagnostics/zm_diagnostics.meta
+++ b/schemes/sima_diagnostics/zm_diagnostics.meta
@@ -57,7 +57,7 @@
   standard_name = lwe_precipitation_rate_at_surface_due_to_deep_convection
   units = m s-1
   type = real | kind = kind_phys
-  dimensions = (1:horizontal_loop_extent)
+  dimensions = (horizontal_loop_extent)
   intent = in
 [ cape ]
   standard_name = zhang_mcfarlane_convective_available_potential_energy

--- a/schemes/sima_diagnostics/zm_evap_tendency_diagnostics.meta
+++ b/schemes/sima_diagnostics/zm_evap_tendency_diagnostics.meta
@@ -63,7 +63,7 @@
   standard_name = tendency_of_dry_air_enthalpy_at_constant_pressure
   units = J kg-1 s-1
   type = real | kind = kind_phys
-  dimensions = (1:horizontal_loop_extent,1:vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = in
 [ errmsg ]
   standard_name = ccpp_error_message

--- a/to_be_ccppized/coords_1d.F90
+++ b/to_be_ccppized/coords_1d.F90
@@ -1,154 +1,149 @@
 module coords_1d
 
-    ! This module defines the Coords1D type, which is intended to to cache
-    ! commonly used information derived from a collection of sets of 1-D
-    ! coordinates.
-    
-    use shr_kind_mod, only: r8 => shr_kind_r8
-    
-    implicit none
-    private
-    save
-    
-    public :: coords1d
+  ! This module defines the Coords1D type, which is intended to to cache
+  ! commonly used information derived from a collection of sets of 1-D
+  ! coordinates.
 
-!! \section arg_table_coords1d
-!! \htmlinclude coords1d.html
-    type :: coords1d
-       ! Number of sets of coordinates in the object.
-       integer :: n = 0
-       ! Number of coordinates in each set.
-       integer :: d = 0
-    
-       ! All fields below will be allocated with first dimension "n".
-       ! The second dimension is d+1 for ifc, d for mid, del, and rdel, and
-       ! d-1 for dst and rdst.
-    
-       ! Cell interface coordinates.
-       real(r8), allocatable :: ifc(:,:)
-       ! Coordinates at cell mid-points.
-       real(r8), allocatable :: mid(:,:)
-       ! Width of cells.
-       real(r8), allocatable :: del(:,:)
-       ! Distance between cell midpoints.
-       real(r8), allocatable :: dst(:,:)
-       ! Reciprocals: 1/del and 1/dst.
-       real(r8), allocatable :: rdel(:,:)
-       real(r8), allocatable :: rdst(:,:)
-     contains
-       procedure :: section
-       procedure :: finalize
-    end type coords1d
-    
-    interface Coords1D
-       module procedure new_Coords1D_from_fields
-       module procedure new_Coords1D_from_int
-    end interface
-    
-    contains
-    
-    ! Constructor to create an object from existing data.
-    function new_Coords1D_from_fields(ifc, mid, del, dst, &
-         rdel, rdst) result(coords)
-      real(r8), USE_CONTIGUOUS intent(in) :: ifc(:,:)
-      real(r8), USE_CONTIGUOUS intent(in) :: mid(:,:)
-      real(r8), USE_CONTIGUOUS intent(in) :: del(:,:)
-      real(r8), USE_CONTIGUOUS intent(in) :: dst(:,:)
-      real(r8), USE_CONTIGUOUS intent(in) :: rdel(:,:)
-      real(r8), USE_CONTIGUOUS intent(in) :: rdst(:,:)
-      type(Coords1D) :: coords
-    
-      coords = allocate_coords(size(ifc, 1), size(ifc, 2) - 1)
-    
-      coords%ifc(:,:) = ifc(:,:)
-      coords%mid(:,:) = mid(:,:)
-      coords%del(:,:) = del(:,:)
-      coords%dst(:,:) = dst(:,:)
-      coords%rdel(:,:) = rdel(:,:)
-      coords%rdst(:,:) = rdst(:,:)
-    
-    end function new_Coords1D_from_fields
-    
-    ! Constructor if you only have interface coordinates; derives all the other
-    ! fields.
-    function new_Coords1D_from_int(ifc) result(coords)
-      real(r8), USE_CONTIGUOUS intent(in) :: ifc(:,:)
-      type(Coords1D) :: coords
-    
-      coords = allocate_coords(size(ifc, 1), size(ifc, 2) - 1)
-    
-      coords%ifc(:,:) = ifc(:,:)
-      coords%mid(:,:) = 0.5_r8 * (ifc(:,:coords%d)+ifc(:,2:))
-      coords%del(:,:) = coords%ifc(:,2:) - coords%ifc(:,:coords%d)
-      coords%dst(:,:) = coords%mid(:,2:) - coords%mid(:,:coords%d-1)
-      coords%rdel(:,:) = 1._r8/coords%del(:,:)
-      coords%rdst(:,:) = 1._r8/coords%dst(:,:)
-    
-    end function new_Coords1D_from_int
-    
-    ! Create a new Coords1D object that is a subsection of some other object,
-    ! e.g. if you want only the first m coordinates, use d_bnds=[1, m].
-    !
-    ! Originally this used pointers, but it was found to actually be cheaper
-    ! in practice just to make a copy, especially since pointers can impede
-    ! optimization.
-    function section(self, n_bnds, d_bnds)
-      class(Coords1D), intent(in) :: self
-      integer, intent(in) :: n_bnds(2), d_bnds(2)
-      type(Coords1D) :: section
-    
-      section = allocate_coords(n_bnds(2)-n_bnds(1)+1, d_bnds(2)-d_bnds(1)+1)
-    
-      section%ifc(:,:) = self%ifc(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)+1)
-      section%mid(:,:) = self%mid(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
-      section%del(:,:) = self%del(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
-      section%dst(:,:) = self%dst(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)-1)
-      section%rdel(:,:) = self%rdel(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
-      section%rdst(:,:) = self%rdst(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)-1)
-    
-    end function section
-    
-    ! Quick utility to get allocate each array with the correct size.
-    function allocate_coords(n, d) result(coords)
-      integer, intent(in) :: n, d
-      type(Coords1D) :: coords
-    
-      coords%n = n
-      coords%d = d
-    
-      allocate(coords%ifc(coords%n,coords%d+1))
-      allocate(coords%mid(coords%n,coords%d))
-      allocate(coords%del(coords%n,coords%d))
-      allocate(coords%dst(coords%n,coords%d-1))
-      allocate(coords%rdel(coords%n,coords%d))
-      allocate(coords%rdst(coords%n,coords%d-1))
-    
-    end function allocate_coords
-    
-    ! Deallocate and reset to initial state.
-    subroutine finalize(self)
-      class(Coords1D), intent(inout) :: self
-    
-      self%n = 0
-      self%d = 0
-    
-      call guarded_deallocate(self%ifc)
-      call guarded_deallocate(self%mid)
-      call guarded_deallocate(self%del)
-      call guarded_deallocate(self%dst)
-      call guarded_deallocate(self%rdel)
-      call guarded_deallocate(self%rdst)
-    
-    contains
-    
-      subroutine guarded_deallocate(array)
-        real(r8), allocatable :: array(:,:)
-    
-        if (allocated(array)) deallocate(array)
-    
-      end subroutine guarded_deallocate
-    
-    end subroutine finalize
-    
+  use shr_kind_mod, only: r8 => shr_kind_r8
+
+  implicit none
+  private
+  save
+
+  public :: coords1d
+
+  !! \section arg_table_coords1d
+  !! \htmlinclude coords1d.html
+  type :: coords1d
+     ! Number of sets of coordinates in the object.
+     integer :: n = 0
+     ! Number of coordinates in each set.
+     integer :: d = 0
+
+     ! All fields below will be allocated with first dimension "n".
+     ! The second dimension is d+1 for ifc, d for mid, del, and rdel, and
+     ! d-1 for dst and rdst.
+
+     ! Cell interface coordinates.
+     real(r8), allocatable :: ifc(:,:)
+     ! Coordinates at cell mid-points.
+     real(r8), allocatable :: mid(:,:)
+     ! Width of cells.
+     real(r8), allocatable :: del(:,:)
+     ! Distance between cell midpoints.
+     real(r8), allocatable :: dst(:,:)
+     ! Reciprocals: 1/del and 1/dst.
+     real(r8), allocatable :: rdel(:,:)
+     real(r8), allocatable :: rdst(:,:)
+  contains
+     procedure :: section
+     procedure :: finalize            ! User-callable
+     final     :: finalize_Coords1D   ! Auto-finalize
+  end type coords1d
+
+  interface Coords1D
+     module procedure new_Coords1D_from_fields
+     module procedure new_Coords1D_from_int
+  end interface
+
+contains
+
+  ! Constructor to create an object from existing data.
+  function new_Coords1D_from_fields(ifc, mid, del, dst, &
+       rdel, rdst) result(coords)
+    real(r8), USE_CONTIGUOUS intent(in) :: ifc(:,:)
+    real(r8), USE_CONTIGUOUS intent(in) :: mid(:,:)
+    real(r8), USE_CONTIGUOUS intent(in) :: del(:,:)
+    real(r8), USE_CONTIGUOUS intent(in) :: dst(:,:)
+    real(r8), USE_CONTIGUOUS intent(in) :: rdel(:,:)
+    real(r8), USE_CONTIGUOUS intent(in) :: rdst(:,:)
+    type(Coords1D) :: coords
+
+    coords = allocate_coords(size(ifc, 1), size(ifc, 2) - 1)
+
+    coords%ifc = ifc
+    coords%mid = mid
+    coords%del = del
+    coords%dst = dst
+    coords%rdel = rdel
+    coords%rdst = rdst
+
+  end function new_Coords1D_from_fields
+
+  ! Constructor if you only have interface coordinates; derives all the other
+  ! fields.
+  function new_Coords1D_from_int(ifc) result(coords)
+    real(r8), USE_CONTIGUOUS intent(in) :: ifc(:,:)
+    type(Coords1D) :: coords
+
+    coords = allocate_coords(size(ifc, 1), size(ifc, 2) - 1)
+
+    coords%ifc = ifc
+    coords%mid = 0.5_r8 * (ifc(:,:coords%d)+ifc(:,2:))
+    coords%del = coords%ifc(:,2:) - coords%ifc(:,:coords%d)
+    coords%dst = coords%mid(:,2:) - coords%mid(:,:coords%d-1)
+    coords%rdel = 1._r8/coords%del
+    coords%rdst = 1._r8/coords%dst
+
+  end function new_Coords1D_from_int
+
+  ! Create a new Coords1D object that is a subsection of some other object,
+  ! e.g. if you want only the first m coordinates, use d_bnds=[1, m].
+  !
+  ! Originally this used pointers, but it was found to actually be cheaper
+  ! in practice just to make a copy, especially since pointers can impede
+  ! optimization.
+  function section(self, n_bnds, d_bnds)
+    class(Coords1D), intent(in) :: self
+    integer, intent(in) :: n_bnds(2), d_bnds(2)
+    type(Coords1D) :: section
+
+    section = allocate_coords(n_bnds(2)-n_bnds(1)+1, d_bnds(2)-d_bnds(1)+1)
+
+    section%ifc(:,:)  = self%ifc(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)+1)
+    section%mid(:,:)  = self%mid(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
+    section%del(:,:)  = self%del(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
+    section%dst(:,:)  = self%dst(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)-1)
+    section%rdel(:,:) = self%rdel(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2))
+    section%rdst(:,:) = self%rdst(n_bnds(1):n_bnds(2),d_bnds(1):d_bnds(2)-1)
+
+  end function section
+
+  ! Quick utility to get allocate each array with the correct size.
+  function allocate_coords(n, d) result(coords)
+    integer, intent(in) :: n, d
+    type(Coords1D) :: coords
+
+    coords%n = n
+    coords%d = d
+
+    allocate(coords%ifc(coords%n,coords%d+1))
+    allocate(coords%mid(coords%n,coords%d))
+    allocate(coords%del(coords%n,coords%d))
+    allocate(coords%dst(coords%n,coords%d-1))
+    allocate(coords%rdel(coords%n,coords%d))
+    allocate(coords%rdst(coords%n,coords%d-1))
+
+  end function allocate_coords
+
+  subroutine finalize(this)
+    class(Coords1D), intent(inout) :: this
+    call finalize_Coords1D(this)
+  end subroutine finalize
+
+  ! Deallocate and reset to initial state.
+  subroutine finalize_Coords1D(this)
+    type(Coords1D) :: this
+
+    this%n = 0
+    this%d = 0
+    if(allocated(this%ifc))  deallocate(this%ifc)
+    if(allocated(this%mid))  deallocate(this%mid)
+    if(allocated(this%del))  deallocate(this%del)
+    if(allocated(this%dst))  deallocate(this%dst)
+    if(allocated(this%rdel)) deallocate(this%rdel)
+    if(allocated(this%rdst)) deallocate(this%rdst)
+
+  end subroutine finalize_Coords1D
+
 end module coords_1d
-    


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):  atmos_phys0_18_001
Originator(s): peverwhee, jimmielin, nusbaume

List all `development` PR numbers included in this PR and the title of each:

 - ESCOMP/atmospheric_physics#314 - Initialize shear squared and Richardson number to zeroes outside of turbulence region in the HB PBL scheme
 - ESCOMP/atmospheric_physics#268 - Changes to reduce potential memory leaks
 - ESCOMP/atmospheric_physics#264 - CCPP framework only allows standard names as dimension indices

List all automated tests that failed, as well as an explanation for why they weren't fixed:
