### PR TITLE
Remove tricking messages in RRTMGP

### DIFF
--- a/schemes/rrtmgp/rrtmgp_inputs.F90
+++ b/schemes/rrtmgp/rrtmgp_inputs.F90
@@ -11,7 +11,7 @@ module rrtmgp_inputs
 !! \htmlinclude rrtmgp_inputs_run.html
 !!
   subroutine rrtmgp_inputs_run(dosw, dolw, snow_associated, graupel_associated, &
-                  is_root, iulog, is_mpas, pmid, pint, t, nday, idxday,          &
+                  is_mpas, pmid, pint, t, nday, idxday,                         &
                   cldfprime, coszrs, kdist_sw, t_sfc, emis_sfc, t_rad,          &
                   pmid_rad, pint_rad, t_day, pmid_day, pint_day, coszrs_day,    &
                   alb_dir, alb_dif, lwup, stebol, ncol, ktopcam, ktoprad, &
@@ -43,9 +43,7 @@ module rrtmgp_inputs
      logical,                              intent(in) :: dolw                  ! Flag for performing the longwave calculation
      logical,                              intent(in) :: snow_associated       ! Flag for whether the cloud snow fraction argument should be used
      logical,                              intent(in) :: graupel_associated    ! Flag for whether the cloud graupel fraction argument should be used
-     logical,                              intent(in) :: is_root
      logical,                              intent(in) :: is_mpas
-     integer,                              intent(in) :: iulog
      integer,         dimension(:),        intent(in) :: idxday                ! Indices of daylight columns
      real(kind_phys), dimension(:,:),      intent(in) :: pmid                  ! Air pressure at midpoint (Pa)
      real(kind_phys), dimension(:,:),      intent(in) :: pint                  ! Air pressure at interface (Pa)
@@ -124,14 +122,6 @@ module rrtmgp_inputs
      else
         ! we cannot or don't need to trick rrtmgp
         ltrick_rrtmgp = .false.
-     end if
-
-     if (is_root) then
-        if (ltrick_rrtmgp) then
-           write(iulog,*) ' *** TRICKING RRTMGP INTO GOING AN EXTRA LEVEL  ',nlay,pverp
-        else
-           write(iulog,*) ' *** CANT or WONT trick RRTMGP ',nlay,pverp
-        end if
      end if
 
      ! RRTMGP set state


### PR DESCRIPTION
Originator(s): peverwhee

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
Remove cluttering RRTMGP tricking messages.

List all namelist files that were added or changed: n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M    schemes/rrtmgp/rrtmgp_inputs.F90
- remove messages and no-longer-needed input arguments

List all automated tests that failed, as well as an explanation for why they weren't fixed: n/a

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? no

If yes to the above question, describe how this code was validated with the new/modified features:
