### PR TITLE
Removed unused rice (reserved ice) from ZM; assorted clean-up

### DIFF
--- a/schemes/zhang_mcfarlane/zm_conv_evap.F90
+++ b/schemes/zhang_mcfarlane/zm_conv_evap.F90
@@ -93,7 +93,6 @@ subroutine zm_conv_evap_run(ncol, pver, pverp, &
 
     real(kind_phys) :: kemask
     real(kind_phys) :: evplimit               ! temp variable for evaporation limits
-    real(kind_phys) :: rlat(ncol)
     real(kind_phys) :: dum
     real(kind_phys) :: omsm
 

--- a/schemes/zhang_mcfarlane/zm_convr.F90
+++ b/schemes/zhang_mcfarlane/zm_convr.F90
@@ -197,8 +197,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
 !  wg * dp       layer thickness in mbs (between upper/lower interface).
 !  wg * dqdt     mixing ratio tendency at gathered points.
 !  wg * dsdt     dry static energy ("temp") tendency at gathered points.
-!  wg * dudt     u-wind tendency at gathered points.
-!  wg * dvdt     v-wind tendency at gathered points.
 !  wg * dsubcld  layer thickness in mbs between lcl and maxi.
 !  ic  * grav     acceleration due to gravity in m/sec2.
 !  wg * du       detrainment in updraft. specified in mid-layer
@@ -348,7 +346,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
    real(kind_phys) cug(ncol,pver)    ! gathered condensation rate
 
    real(kind_phys) evpg(ncol,pver)   ! gathered evap rate of rain in downdraft
-   real(kind_phys) dptot(ncol)
 
    real(kind_phys) mumax(ncol)
 
@@ -379,7 +376,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
    integer lon(ncol)                  ! w  index of onset level for deep convection.
    integer maxi(ncol)                 ! w  index of level with largest moist static energy.
 
-   real(kind_phys) precip
 !
 ! gathered work fields:
 !
@@ -418,8 +414,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
    real(kind_phys) hmn(ncol,pver)            ! wg moist static energy.
    real(kind_phys) hsat(ncol,pver)           ! wg saturated moist static energy.
    real(kind_phys) qlg(ncol,pver)
-   real(kind_phys) dudt(ncol,pver)           ! wg u-wind tendency at gathered points.
-   real(kind_phys) dvdt(ncol,pver)           ! wg v-wind tendency at gathered points.
 
    real(kind_phys) qldeg(ncol,pver)        ! cloud liquid water mixing ratio for detrainment (kg/kg)
    real(kind_phys) mb(ncol)                ! wg cloud base mass flux.
@@ -431,8 +425,7 @@ subroutine zm_convr_run(     ncol    ,pver    , &
    real(kind_phys),intent(in):: delt                     ! length of model time-step in seconds.
 
    integer i
-   integer ii
-   integer k, kk, l, m
+   integer k, l, m
 
    integer msg                      !  ic number of missing moisture levels at the top of model.
    real(kind_phys) qdifr
@@ -440,8 +433,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
 
    real(kind_phys), parameter :: dcon  = 25.e-6_kind_phys
    real(kind_phys), parameter :: mucon = 5.3_kind_phys
-   real(kind_phys) negadq
-   logical doliq
 
 
 !
@@ -473,8 +464,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
       do i = 1,ncol
          dqdt(i,k)  = 0._kind_phys
          dsdt(i,k)  = 0._kind_phys
-         dudt(i,k)  = 0._kind_phys
-         dvdt(i,k)  = 0._kind_phys
          cme(i,k)   = 0._kind_phys
          rprd(i,k)  = 0._kind_phys
          zdu(i,k)   = 0._kind_phys
@@ -871,14 +860,9 @@ subroutine buoyan_dilute(  ncol   ,pver    , &
    real(kind_phys) tpv(ncol,pver)      !
    real(kind_phys) buoy(ncol,pver)
 
-   real(kind_phys) a1(ncol)
-   real(kind_phys) a2(ncol)
-   real(kind_phys) estp(ncol)
    real(kind_phys) pl(ncol)
-   real(kind_phys) plexp(ncol)
    real(kind_phys) hmax(ncol)
    real(kind_phys) hmn(ncol)
-   real(kind_phys) y(ncol)
 
    logical plge600(ncol)
    integer knt(ncol)
@@ -909,7 +893,6 @@ subroutine buoyan_dilute(  ncol   ,pver    , &
 
 
    real(kind_phys) cp
-   real(kind_phys) e
    real(kind_phys) grav
 
    integer i
@@ -1206,7 +1189,6 @@ real(kind_phys) smix(ncol,pver)        ! Entropy of the entraining parcel.
 real(kind_phys) xsh2o(ncol,pver)       ! Precipitate lost from parcel.
 real(kind_phys) ds_xsh2o(ncol,pver)    ! Entropy change due to loss of condensate.
 real(kind_phys) ds_freeze(ncol,pver)   ! Entropy change sue to freezing of precip.
-real(kind_phys) dmpdz2d(ncol,pver)     ! variable detrainment rate
 
 real(kind_phys) mp(ncol)    ! Parcel mass flux.
 real(kind_phys) qtp(ncol)   ! Parcel total water.
@@ -1233,7 +1215,6 @@ real(kind_phys) tscool     ! Super cooled temperature offset (in degC) (eg -35).
 real(kind_phys) qxsk, qxskp1        ! LCL excess water (k, k+1)
 real(kind_phys) dsdp, dqtdp, dqxsdp ! LCL s, qt, p gradients (k, k+1)
 real(kind_phys) slcl,qtlcl,qslcl    ! LCL s, qt, qs values.
-real(kind_phys) dmpdz_lnd, dmpdz_mask
 
 integer rcall       ! Number of ientropy call for errors recording
 integer nit_lheat     ! Number of iterations for condensation/freezing loop.
@@ -1254,7 +1235,6 @@ integer i,k,ii   ! Loop counters.
 
 nit_lheat = 2 ! iterations for ds,dq changes from condensation freezing.
 dmpdz=dmpdz_param       ! Entrainment rate. (-ve for /m)
-dmpdz_lnd=-1.e-3_kind_phys
 lwmax = 1.e-3_kind_phys    ! Need to put formula in for this.
 tscool = 0.0_kind_phys   ! Temp at which water loading freezes in the cloud.
 
@@ -1757,13 +1737,9 @@ subroutine cldprp(ncol   ,pver    ,pverp   ,cpliq   , &
    real(kind_phys) small
    real(kind_phys) mdt
 
-   real(kind_phys) tug(ncol,pver)
 
-   real(kind_phys) tvuo(ncol,pver)        ! updraft virtual T w/o freezing heating
-   real(kind_phys) tvu(ncol,pver)         ! updraft virtual T with freezing heating
    real(kind_phys) totfrz(ncol)
    real(kind_phys) frz (ncol,pver)        ! rate of freezing
-   integer  jto(ncol)              ! updraft plume old top
    integer  tmplel(ncol)
 
    integer  iter, itnum
@@ -1834,10 +1810,7 @@ subroutine cldprp(ncol   ,pver    ,pverp   ,cpliq   , &
          hd(i,k) = hmn(i,k)
          rprd(i,k) = 0._kind_phys
 
-         tug(i,k)  = 0._kind_phys
          qcde(i,k)   = 0._kind_phys
-         tvuo(i,k) = (shat(i,k) - grav/cp*zf(i,k))*(1._kind_phys + 0.608_kind_phys*qhat(i,k))
-         tvu(i,k) = tvuo(i,k)
          frz(i,k)  = 0._kind_phys
 
       end do
@@ -2097,8 +2070,6 @@ subroutine cldprp(ncol   ,pver    ,pverp   ,cpliq   , &
             end if
          end do
       end do
-
-      if (iter == 1)  jto(:) = jt(:)
 
       do k = pver,msg + 1,-1
          do i = 1,il2g

--- a/schemes/zhang_mcfarlane/zm_convr.F90
+++ b/schemes/zhang_mcfarlane/zm_convr.F90
@@ -161,11 +161,11 @@ subroutine zm_convr_run(     ncol    ,pver    , &
                     pblh    ,zm      ,geos    ,zi      ,qtnd    , &
                     heat    ,pap     ,paph    ,dpp     , &
                     delt    ,mcon    ,cme     ,cape    , &
-                    tpert   ,dlf     ,dif     ,zdu     ,rprd    , &
+                    tpert   ,dlf     ,zdu     ,rprd    , &
                     mu      ,md      ,du      ,eu      ,ed      , &
                     dp      ,dsubcld ,jt      ,maxg    ,ideep   , &
                     ql      ,rliq    ,landfrac,                   &
-                    rice    ,lengath ,scheme_name, errmsg  ,errflg)
+                    lengath ,scheme_name, errmsg  ,errflg)
 !-----------------------------------------------------------------------
 !
 ! Purpose:
@@ -308,7 +308,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
    real(kind_phys), intent(out) :: qtnd(:,:)           ! specific humidity tendency (kg/kg/s)             (ncol,pver)
    real(kind_phys), intent(out) :: heat(:,:)           ! heating rate (dry static energy tendency, W/kg)  (ncol,pver)
    real(kind_phys), intent(out) :: mcon(:,:)  !   (ncol,pverp)
-   real(kind_phys), intent(out) :: dif(:,:)
    real(kind_phys), intent(out) :: dlf(:,:)    ! scattrd version of the detraining cld h2o tend (ncol,pver)
    real(kind_phys), intent(out) :: cme(:,:)    !                                                          (ncol,pver)
    real(kind_phys), intent(out) :: cape(:)        ! w  convective available potential energy.             (ncol)
@@ -326,7 +325,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
    real(kind_phys), intent(out) :: dsubcld(:)       ! wg layer thickness in mbs between lcl and maxi.         (ncol)
    real(kind_phys), intent(out) :: prec(:)  !                                                                 (ncol)
    real(kind_phys), intent(out) :: rliq(:) ! reserved liquid (not yet in cldliq) for energy integrals         (ncol)
-   real(kind_phys), intent(out) :: rice(:) ! reserved ice (not yet in cldce) for energy integrals             (ncol)
 
    integer,  intent(out) :: ideep(:)  ! column indices of gathered points                              (ncol)
 
@@ -466,7 +464,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
    heat(:,:) = 0._kind_phys
    mcon(:,:) = 0._kind_phys
    rliq(:ncol)   = 0._kind_phys
-   rice(:ncol)   = 0._kind_phys
 
 !
 ! initialize convective tendencies
@@ -486,8 +483,6 @@ subroutine zm_convr_run(     ncol    ,pver    , &
          dlf(i,k)   = 0._kind_phys
          dlg(i,k)   = 0._kind_phys
          qldeg(i,k) = 0._kind_phys
-
-         dif(i,k)   = 0._kind_phys
 
       end do
    end do
@@ -762,7 +757,7 @@ subroutine zm_convr_run(     ncol    ,pver    , &
 ! Compute precip by integrating change in water vapor minus detrained cloud water
    do k = pver,msg + 1,-1
       do i = 1,ncol
-          prec(i) = prec(i) - dpp(i,k)* (q(i,k)-qh(i,k)) - dpp(i,k)*(dlf(i,k)+dif(i,k))*delt
+          prec(i) = prec(i) - dpp(i,k)* (q(i,k)-qh(i,k)) - dpp(i,k)*dlf(i,k)*delt
       end do
    end do
 
@@ -775,12 +770,10 @@ subroutine zm_convr_run(     ncol    ,pver    , &
 ! Treat rliq as flux out bottom, to be added back later.
    do k = 1, pver
       do i = 1, ncol
-          rliq(i) = rliq(i) + (dlf(i,k)+dif(i,k))*dpp(i,k)/gravit
-          rice(i) = rice(i) + dif(i,k)*dpp(i,k)/gravit
+          rliq(i) = rliq(i) + dlf(i,k)*dpp(i,k)/gravit
       end do
    end do
    rliq(:ncol) = rliq(:ncol) /1000._kind_phys  ! Converted to precip units m s-1
-   rice(:ncol) = rice(:ncol) /1000._kind_phys  ! Converted to precip units m s-1
 
 ! Convert mass flux from reported mb s-1 to kg m-2 s-1
    mcon(:ncol,:pverp) = mcon(:ncol,:pverp) * 100._kind_phys / gravit

--- a/schemes/zhang_mcfarlane/zm_convr.meta
+++ b/schemes/zhang_mcfarlane/zm_convr.meta
@@ -344,12 +344,6 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = out
-[ dif ]
-  standard_name = detrainment_of_cloud_ice_wrt_moist_air_and_condensed_water_due_to_deep_convection
-  units = kg kg-1 s-1
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  intent = out
 [ zdu ]
   standard_name = detrainment_mass_flux_due_to_deep_convection
   units = s-1
@@ -440,12 +434,6 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
   intent = in
-[ rice ]
-  standard_name = vertically_integrated_cloud_ice_tendency_due_to_all_convection_to_be_applied_later_in_time_loop
-  units = m s-1
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent)
-  intent = out
 [ lengath ]
   standard_name = index_of_last_column_of_gathered_deep_convection_arrays
   units = index


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin 

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Resolves https://github.com/ESCOMP/CAM/issues/1472 when it is merged into CAM
- Removes rice, dif from `zm_convr` interface: requires CAM update

List all namelist files that were added or changed: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
schemes/zhang_mcfarlane/zm_convr.F90
  - removed unused dif, rice - they are always zero as indicated by scientists
  - removed unused local variables as suggested by Nag compiler warnings 
 
schemes/zhang_mcfarlane/zm_conv_evap.F90
  - remove unused rlat local variable
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? 

All B4B

If yes to the above question, describe how this code was validated with the new/modified features:

CAM regression tests
