### PR TITLE
Fix spelling of zmconv_tiedtke_add

### DIFF
--- a/schemes/zhang_mcfarlane/zm_conv_options.F90
+++ b/schemes/zhang_mcfarlane/zm_conv_options.F90
@@ -12,7 +12,7 @@ contains
   subroutine zm_conv_options_init(masterproc, iulog, &
     zmconv_c0_lnd, zmconv_c0_ocn, zmconv_ke, zmconv_ke_lnd, &
     zmconv_momcu, zmconv_momcd, zmconv_num_cin, &
-    no_deep_pbl_in, zmconv_tiedke_add, &
+    no_deep_pbl_in, zmconv_tiedtke_add, &
     zmconv_capelmt, zmconv_dmpdz, zmconv_parcel_pbl, &
     zmconv_parcel_hscale, zmconv_tau)
 
@@ -25,7 +25,7 @@ contains
     real(kind_phys),intent(in)           :: zmconv_momcu
     real(kind_phys),intent(in)           :: zmconv_momcd
     logical, intent(in)                  :: no_deep_pbl_in  ! no_deep_pbl = .true. eliminates ZM convection entirely within PBL
-    real(kind_phys),intent(in)           :: zmconv_tiedke_add
+    real(kind_phys),intent(in)           :: zmconv_tiedtke_add
     real(kind_phys),intent(in)           :: zmconv_capelmt
     real(kind_phys),intent(in)           :: zmconv_dmpdz
     logical, intent(in)                  :: zmconv_parcel_pbl ! Should the parcel properties include PBL mixing?
@@ -42,7 +42,7 @@ contains
       write(iulog,*) 'tuning parameters zm_conv_options_init: no_deep_pbl',no_deep_pbl_in
       write(iulog,*) 'tuning parameters zm_conv_options_init: zm_capelmt', zmconv_capelmt
       write(iulog,*) 'tuning parameters zm_conv_options_init: zm_dmpdz', zmconv_dmpdz
-      write(iulog,*) 'tuning parameters zm_conv_options_init: zm_tiedke_add', zmconv_tiedke_add
+      write(iulog,*) 'tuning parameters zm_conv_options_init: zm_tiedke_add', zmconv_tiedtke_add
       write(iulog,*) 'tuning parameters zm_conv_options_init: zm_parcel_pbl', zmconv_parcel_pbl
       write(iulog,*) 'tuning parameters zm_conv_options_init: zm_parcel_hscale', zmconv_parcel_hscale
     endif

--- a/schemes/zhang_mcfarlane/zm_conv_options.meta
+++ b/schemes/zhang_mcfarlane/zm_conv_options.meta
@@ -65,7 +65,7 @@
   type = logical
   dimensions = ()
   intent = in
-[ zmconv_tiedke_add ]
+[ zmconv_tiedtke_add ]
   standard_name = parcel_temperature_perturbation_for_zhang_mcfarlane_deep_convection_scheme
   units = K
   type = real | kind = kind_phys

--- a/schemes/zhang_mcfarlane/zm_conv_options_namelist.xml
+++ b/schemes/zhang_mcfarlane/zm_conv_options_namelist.xml
@@ -136,7 +136,7 @@
   </values>
 </entry>
 
-<entry id="zmconv_tiedke_add">
+<entry id="zmconv_tiedtke_add">
   <category>conv</category>
   <group>zmconv_nl</group>
   <standard_name>parcel_temperature_perturbation_for_zhang_mcfarlane_deep_convection_scheme</standard_name>

--- a/schemes/zhang_mcfarlane/zm_convr.F90
+++ b/schemes/zhang_mcfarlane/zm_convr.F90
@@ -57,7 +57,7 @@ contains
 subroutine zm_convr_init(plev, plevp, cpair, epsilo, gravit, latvap, tmelt, rair, &
                     pref_edge, zmconv_c0_lnd, zmconv_c0_ocn, zmconv_ke, zmconv_ke_lnd, &
                     zmconv_momcu, zmconv_momcd, zmconv_num_cin, &
-                    no_deep_pbl_in, zmconv_tiedke_add, &
+                    no_deep_pbl_in, zmconv_tiedtke_add, &
                     zmconv_capelmt, zmconv_dmpdz, zmconv_parcel_pbl, zmconv_parcel_hscale, zmconv_tau, &
                     masterproc, iulog, errmsg, errflg)
 
@@ -80,7 +80,7 @@ subroutine zm_convr_init(plev, plevp, cpair, epsilo, gravit, latvap, tmelt, rair
    real(kind_phys),intent(in)           :: zmconv_momcu
    real(kind_phys),intent(in)           :: zmconv_momcd
    logical, intent(in)           :: no_deep_pbl_in  ! no_deep_pbl = .true. eliminates ZM convection entirely within PBL
-   real(kind_phys),intent(in)           :: zmconv_tiedke_add
+   real(kind_phys),intent(in)           :: zmconv_tiedtke_add
    real(kind_phys),intent(in)           :: zmconv_capelmt
    real(kind_phys),intent(in)           :: zmconv_dmpdz
    logical, intent(in)                  :: zmconv_parcel_pbl ! Should the parcel properties include PBL mixing?
@@ -114,7 +114,7 @@ subroutine zm_convr_init(plev, plevp, cpair, epsilo, gravit, latvap, tmelt, rair
    momcu   = zmconv_momcu
    momcd   = zmconv_momcd
 
-   tiedke_add = zmconv_tiedke_add
+   tiedke_add = zmconv_tiedtke_add
    capelmt = zmconv_capelmt
    dmpdz_param = zmconv_dmpdz
    no_deep_pbl = no_deep_pbl_in

--- a/schemes/zhang_mcfarlane/zm_convr.meta
+++ b/schemes/zhang_mcfarlane/zm_convr.meta
@@ -108,7 +108,7 @@
   type = logical
   dimensions = ()
   intent = in
-[ zmconv_tiedke_add ]
+[ zmconv_tiedtke_add ]
   standard_name = parcel_temperature_perturbation_for_zhang_mcfarlane_deep_convection_scheme
   units = K
   type = real | kind = kind_phys


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin 

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Closes https://github.com/ESCOMP/atmospheric_physics/issues/376

List all namelist files that were added or changed:
M       schemes/zhang_mcfarlane/zm_conv_options_namelist.xml

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       schemes/zhang_mcfarlane/zm_conv_options.F90
M       schemes/zhang_mcfarlane/zm_conv_options.meta
M       schemes/zhang_mcfarlane/zm_convr.F90
M       schemes/zhang_mcfarlane/zm_convr.meta
  - fix spelling of namelist option
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

If yes to the above question, describe how this code was validated with the new/modified features:
