### PR TITLE
Move nswbands, nlwbands to host namelist; initialize number concentration species in initialize_constituents

### DIFF
--- a/schemes/rrtmgp/rrtmgp_pre_namelist.xml
+++ b/schemes/rrtmgp/rrtmgp_pre_namelist.xml
@@ -231,32 +231,6 @@
       <value>.false.</value>
     </values>
   </entry>
-  <entry id="nswbands">
-    <type>integer</type>
-    <category>rrtmgp</category>
-    <group>rrtmgp</group>
-    <standard_name>number_of_bands_for_shortwave_radiation</standard_name>
-    <units>count</units>
-    <desc>
-       Number of shortwave bands
-    </desc>
-    <values>
-      <value>14</value>
-    </values>
-  </entry>
-  <entry id="nlwbands">
-    <type>integer</type>
-    <category>rrtmgp</category>
-    <group>rrtmgp</group>
-    <standard_name>number_of_bands_for_longwave_radiation</standard_name>
-    <units>count</units>
-    <desc>
-       Number of longwave bands
-    </desc>
-    <values>
-      <value>16</value>
-    </values>
-  </entry>
   <entry id="nradgas">
     <type>integer</type>
     <category>rrtmgp</category>

--- a/test/test_schemes/initialize_constituents.F90
+++ b/test/test_schemes/initialize_constituents.F90
@@ -36,31 +36,32 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
     character(len=256), allocatable :: constituent_names(:)
     character(len=256), allocatable :: const_diag_names(:)
     character(len=65), parameter :: water_species_std_names(6) = &
-      (/'water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water       ', &
+       ['water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water       ', &
         'cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', &
         'rain_mixing_ratio_wrt_moist_air_and_condensed_water              ', &
         'cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water         ', &
         'snow_mixing_ratio_wrt_moist_air_and_condensed_water              ', &
-        'graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water     '/)
+        'graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water     ']
 
-    character(len=11), parameter :: const_file_names(6) = (/'cnst_Q     ', &
+    character(len=11), parameter :: const_file_names(6) = &
+                                                ['cnst_Q     ', &
                                                  'cnst_CLDLIQ', &
                                                  'cnst_RAINQM', &
                                                  'cnst_CLDICE', &
                                                  'cnst_SNOWQM', &
-                                                 'cnst_GRAUQM'/)
+                                                 'cnst_GRAUQM']
     character(len=11), parameter :: water_species_number_concentrations(5) = &
-                                      (/'cnst_NUMLIQ', &
+                                       ['cnst_NUMLIQ', &
                                         'cnst_NUMRAI', &
                                         'cnst_NUMICE', &
                                         'cnst_NUMSNO', &
-                                        'cnst_NUMGRA'/)
+                                        'cnst_NUMGRA']
     character(len=75), parameter :: water_species_number_std_names(5) = &
-      (/'mass_number_concentration_of_cloud_liquid_wrt_moist_air_and_condensed_water', &
+       ['mass_number_concentration_of_cloud_liquid_wrt_moist_air_and_condensed_water', &
         'mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water        ', &
         'mass_number_concentration_of_ice_wrt_moist_air_and_condensed_water         ', &
         'mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water        ', &
-        'mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water     '/)
+        'mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water     ']
 
     errcode = 0
     errmsg = ''
@@ -159,7 +160,7 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
              errmsg = errmsg)
        else
           ! For chemistry species some special handling is necessary for qmin_value;
-          ! this logic is replicated from chem_register in src/chemistry/mozart.
+          ! this logic is replicated from chem_register in src/chemistry/mozart in CAM.
           qmin_value = 0.0_kind_phys
           cnst_stdname = trim(constituent_names(var_index))
           ! Special handling for specific chemical species

--- a/test/test_schemes/initialize_constituents.F90
+++ b/test/test_schemes/initialize_constituents.F90
@@ -29,6 +29,8 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
     integer :: known_const_index
     integer :: found_const_count
     logical :: known_constituent
+    real(kind_phys) :: qmin_value
+    character(len=256) :: cnst_stdname
     character(len=256) :: variable_name
     character(len=512) :: alloc_err_msg
     character(len=256), allocatable :: constituent_names(:)
@@ -53,6 +55,12 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
                                         'cnst_NUMICE', &
                                         'cnst_NUMSNO', &
                                         'cnst_NUMGRA'/)
+    character(len=75), parameter :: water_species_number_std_names(5) = &
+      (/'mass_number_concentration_of_cloud_liquid_wrt_moist_air_and_condensed_water', &
+        'mass_number_concentration_of_rain_wrt_moist_air_and_condensed_water        ', &
+        'mass_number_concentration_of_ice_wrt_moist_air_and_condensed_water         ', &
+        'mass_number_concentration_of_snow_wrt_moist_air_and_condensed_water        ', &
+        'mass_number_concentration_of_graupel_wrt_moist_air_and_condensed_water     '/)
 
     errcode = 0
     errmsg = ''
@@ -95,6 +103,16 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
                 end if
              end do
           end if
+          ! Also check number concentration species
+          if (.not. known_constituent) then
+             do known_const_index = 1, size(water_species_number_concentrations)
+                if (trim(water_species_number_concentrations(known_const_index)) == trim(variable_name)) then
+                   constituent_names(constituent_index) = water_species_number_std_names(known_const_index)
+                   known_constituent = .true.
+                   exit
+                end if
+             end do
+          end if
           if (.not. known_constituent) then
              constituent_names(constituent_index) = variable_name
           end if
@@ -109,7 +127,10 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
     end if
 
     do var_index = 1, size(constituents)
-       if (any(water_species_number_concentrations == trim(constituent_names(var_index)))) then
+       if (any(water_species_number_std_names == trim(constituent_names(var_index)))) then
+          ! Do not set water_species = .true. for water species number concentrations
+          !   Avoiding mismatch in properties vs. metadata-specified constituents
+          !   Water species properties are set in air_composition.F90 in CAM-SIMA
           call constituents(var_index)%instantiate(     &
              std_name = constituent_names(var_index),   &
              long_name = constituent_names(var_index),  &
@@ -118,7 +139,6 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
              min_value = 0.0_kind_phys,                 &
              advected = .true.,                         &
              diag_name = const_diag_names(var_index),   &
-             water_species = .true.,                    &
              mixing_ratio_type = 'wet',                 &
              errcode = errcode,                         &
              errmsg = errmsg)
@@ -133,17 +153,42 @@ subroutine initialize_constituents_register(constituents, errmsg, errcode)
              vertical_dim = 'vertical_layer_dimension', &
              min_value = 0.0_kind_phys,                 &
              advected = .true.,                         &
-             diag_name = const_diag_names(var_index),   & 
+             diag_name = const_diag_names(var_index),   &
              mixing_ratio_type = 'wet',                 &
              errcode = errcode,                         &
              errmsg = errmsg)
        else
+          ! For chemistry species some special handling is necessary for qmin_value;
+          ! this logic is replicated from chem_register in src/chemistry/mozart.
+          qmin_value = 0.0_kind_phys
+          cnst_stdname = trim(constituent_names(var_index))
+          ! Special handling for specific chemical species
+          ! Aerosol number density species
+          if (index(cnst_stdname, 'num_a') > 0) then
+             qmin_value = 1.e-5_kind_phys
+          else if (index(cnst_stdname, 'O3') > 0) then
+             qmin_value = 1.e-12_kind_phys
+          else if (index(cnst_stdname, 'CH4') > 0) then
+             qmin_value = 1.e-12_kind_phys
+          else if (index(cnst_stdname, 'N2O') > 0) then
+             qmin_value = 1.e-15_kind_phys
+          ! CFCs
+          else if (index(cnst_stdname, 'CFC11') > 0 .or. &
+                   index(cnst_stdname, 'CFC12') > 0 .or. &
+                   index(cnst_stdname, 'cfc11') > 0 .or. &
+                   index(cnst_stdname, 'cfc12') > 0) then
+             qmin_value = 1.e-20_kind_phys
+          end if
+          ! Note: other chemistry species should be 1e-36 but we have no way
+          ! of currently distinguishing between these and other non-chem
+          ! constituents, so leaving as 0.0_kind_phys for now. (hplin, 11/20/25)
+
           call constituents(var_index)%instantiate(     &
              std_name = constituent_names(var_index),   &
              long_name = constituent_names(var_index),  &
              units = 'kg kg-1',                         &
              vertical_dim = 'vertical_layer_dimension', &
-             min_value = 0.0_kind_phys,                 &
+             min_value = qmin_value,                    &
              advected = .true.,                         &
              diag_name = const_diag_names(var_index),   &
              errcode = errcode,                         &


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin 

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Moves `nswbands`, `nlwbands` to host-side radiation_namelist (CAM-SIMA companion PR: https://github.com/ESCOMP/CAM-SIMA/pull/493)
- Closes #332
- Initializes number concentration species (NUMLIQ, NUMICE, ...) in the test `initialize_constituents.F90` scheme.

List all namelist files that were added or changed:
```
M       schemes/rrtmgp/rrtmgp_pre_namelist.xml
  - moved nlwbands, nswbands to host-side (no effect on CAM)
```

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       schemes/rrtmgp/rrtmgp_pre_namelist.xml
  - moved nlwbands, nswbands to host-side (no effect on CAM)
  
M       test/test_schemes/initialize_constituents.F90
  - add number concentration species standard names and logic
  - set qmin for chemistry species based on mozart initialization in CAM.
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

If yes to the above question, describe how this code was validated with the new/modified features:
