### PR TITLE
Fix CAM#1550 - ZM scheme no longer conserving energy - put back 0.5 factor for KE & PR template update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ List all files eliminated and why:
 List all files added and what they do:
 
 List all existing files that have been modified, and describe the changes:
-(Helpful git command: `git diff --name-status development...<your_branch_name>`)
+(Helpful git command: `git diff --name-status main...<your_branch_name>`)
 
 List all automated tests that failed, as well as an explanation for why they weren't fixed:
 

--- a/schemes/zhang_mcfarlane/zm_conv_momtran.F90
+++ b/schemes/zhang_mcfarlane/zm_conv_momtran.F90
@@ -420,7 +420,7 @@ subroutine zm_conv_momtran_run(ncol, pver, pverp, &
           ketend_cons = (fket-fkeb)/dp(i,k)
 
           ! tendency in kinetic energy resulting from the momentum transport
-          ketend = ((windf(i,k,1)**2 + windf(i,k,2)**2) - (wind0(i,k,1)**2 + wind0(i,k,2)**2))/dt
+          ketend = 0.5_kind_phys * ((windf(i,k,1)**2 + windf(i,k,2)**2) - (wind0(i,k,1)**2 + wind0(i,k,2)**2))/dt
 
           ! the difference should be the dissipation
           gset2 = ketend_cons - ketend


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin 

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Fixes https://github.com/ESCOMP/CAM/issues/1550
- Update reference branch in PR template to `main` as we retire `development`

List all namelist files that were added or changed: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       schemes/zhang_mcfarlane/zm_conv_momtran.F90
  - put back 0.5 factor in kinetic energy

M       .github/pull_request_template.md
  - update reference of development to main
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

If yes to the above question, describe how this code was validated with the new/modified features:
