### PR TITLE
SIMA patch for fixing energy bug in physics-dynamics coupling

### DIFF
--- a/schemes/conservation_adjust/check_energy/check_energy_chng.meta
+++ b/schemes/conservation_adjust/check_energy/check_energy_chng.meta
@@ -96,7 +96,7 @@
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
 [ cp_or_cv_dycore ]
-  standard_name = specific_heat_of_air_used_in_dycore
+  standard_name = specific_heat_of_air_used_in_dycore_at_start_of_physics_timestep
   units = J kg-1 K-1
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension)
@@ -280,13 +280,13 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ cp_or_cv_dycore ]
-  standard_name = specific_heat_of_air_used_in_dycore
+  standard_name = specific_heat_of_air_used_in_dycore_at_start_of_physics_timestep
   units = J kg-1 K-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ scaling_dycore ]
-  standard_name = ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
+  standard_name = ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula_at_start_of_physics_timestep
   units = 1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/schemes/conservation_adjust/check_energy/check_energy_scaling.meta
+++ b/schemes/conservation_adjust/check_energy/check_energy_scaling.meta
@@ -12,7 +12,7 @@
   dimensions = ()
   intent = in
 [ cp_or_cv_dycore ]
-  standard_name = specific_heat_of_air_used_in_dycore
+  standard_name = specific_heat_of_air_used_in_dycore_at_start_of_physics_timestep
   units = J kg-1 K-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -24,7 +24,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ scaling_dycore ]
-  standard_name = ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
+  standard_name = ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula_at_start_of_physics_timestep
   units = 1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/schemes/conservation_adjust/check_energy/dycore_energy_consistency_adjust.meta
+++ b/schemes/conservation_adjust/check_energy/dycore_energy_consistency_adjust.meta
@@ -24,7 +24,7 @@
   dimensions = ()
   intent = in
 [ scaling_dycore ]
-  standard_name = ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
+  standard_name = ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula_at_start_of_physics_timestep
   units = 1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/schemes/sima_diagnostics/check_energy_diagnostics.F90
+++ b/schemes/sima_diagnostics/check_energy_diagnostics.F90
@@ -27,8 +27,8 @@ CONTAINS
       errflg = 0
 
       ! History add field calls
-      call history_add_field('cp_or_cv_dycore', 'specific_heat_of_air_used_in_dycore', 'lev', 'inst', 'J kg-1 K-1')
-      call history_add_field('scaling_dycore', 'ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula', 'lev', 'inst', '1')
+      call history_add_field('cp_or_cv_dycore', 'specific_heat_of_air_used_in_dycore_at_start_of_physics_timestep', 'lev', 'inst', 'J kg-1 K-1')
+      call history_add_field('scaling_dycore', 'ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula_at_start_of_physics_timestep', 'lev', 'inst', '1')
 
       call history_add_field('te_cur_phys', 'vertically_integrated_total_energy_using_physics_energy_formula', horiz_only, 'inst', 'J m-2')
       call history_add_field('tw_cur', 'vertically_integrated_total_water', horiz_only, 'inst', 'kg m-2')

--- a/schemes/sima_diagnostics/check_energy_diagnostics.meta
+++ b/schemes/sima_diagnostics/check_energy_diagnostics.meta
@@ -22,13 +22,13 @@
   name  = check_energy_diagnostics_run
   type  = scheme
 [ cp_or_cv_dycore ]
-  standard_name = specific_heat_of_air_used_in_dycore
+  standard_name = specific_heat_of_air_used_in_dycore_at_start_of_physics_timestep
   units = J kg-1 K-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ scaling_dycore ]
-  standard_name = ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula
+  standard_name = ratio_of_specific_heat_of_air_used_in_physics_energy_formula_to_specific_heat_of_air_used_in_dycore_energy_formula_at_start_of_physics_timestep
   units = 1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/suites/suite_cam4.xml
+++ b/suites/suite_cam4.xml
@@ -406,13 +406,30 @@
     <!-- Save current total energy from dycore for energy fixer in time step. Total energy in current state is updated by the last check_energy_chng call. -->
     <scheme>check_energy_save_teout</scheme>
 
+    <!-- thermo_water_update prepares cp_or_cv_dycore for post-physics
+         total-energy diagnostics (i.e., tot_energy_phys in CAM).
+         COMMENTED OUT: CAM-SIMA does not have tot_energy_phys diagnostics
+         yet, thus cp_or_cv_dycore does not need to be updated mid-physics
+         at this time.
+
+         check_energy_scaling reads cp_or_cv_dycore_at_start_of_physics_timestep
+         (computed in d_p_coupling/dyn_coupling_impl) instead
+         and should not use mid-physics timestep updated values (see CAM#1554).
+         Re-enable once dme_adjust is enabled and tot_energy_physics diagnostics
+         are implemented. -->
+    <!-- <scheme>thermo_water_update</scheme> -->
+
     <!-- Dry Mass and Energy adjust -->
     <!-- COMMENTED OUT until qini/liqini/iceini have initialization routines -->
     <!-- See https://github.com/ESCOMP/atmospheric_physics/issues/222 -->
     <!-- <scheme>dme_adjust</scheme> -->
 
     <!-- MPAS and SE specific scaling of temperature for enforcing energy consistency:
-         First, calculate the scaling based off cp_or_cv_dycore (from cam_thermo_water_update)
+         First, calculate the scaling based off the start-of-physics snapshot
+         cp_or_cv_dycore_at_start_of_physics_timestep (computed in d_p_coupling/
+         dyn_coupling_impl).
+         Any mid-physics mutation of cp_or_cv_dycore by thermo_water_update
+         should not be used.
          Then, perform the temperature and temperature tendency scaling -->
     <scheme>check_energy_scaling</scheme>
     <scheme>dycore_energy_consistency_adjust</scheme>

--- a/suites/suite_cam7.xml
+++ b/suites/suite_cam7.xml
@@ -145,8 +145,18 @@
     <!-- Save current total energy from dycore for energy fixer in time step. Total energy in current state is updated by the last check_energy_chng call. -->
     <scheme>check_energy_save_teout</scheme>
 
-    <!-- Update cp/cv for energy computation based in updated water variables -->
-    <scheme>thermo_water_update</scheme>
+    <!-- thermo_water_update prepares cp_or_cv_dycore for post-physics
+         total-energy diagnostics (i.e., tot_energy_phys in CAM).
+         COMMENTED OUT: CAM-SIMA does not have tot_energy_phys diagnostics
+         yet, thus cp_or_cv_dycore does not need to be updated mid-physics
+         at this time.
+
+         check_energy_scaling reads cp_or_cv_dycore_at_start_of_physics_timestep
+         (computed in d_p_coupling/dyn_coupling_impl) instead
+         and should not use mid-physics timestep updated values (see CAM#1554).
+         Re-enable once dme_adjust is enabled and tot_energy_physics diagnostics
+         are implemented. -->
+    <!-- <scheme>thermo_water_update</scheme> -->
 
     <!-- Dry Mass and Energy adjust -->
     <!-- COMMENTED OUT until qini/liqini/iceini have initialization routines -->
@@ -154,7 +164,11 @@
     <!-- <scheme>dme_adjust</scheme> -->
 
     <!-- MPAS and SE specific scaling of temperature for enforcing energy consistency:
-         First, calculate the scaling based off cp_or_cv_dycore (from cam_thermo_water_update)
+         First, calculate the scaling based off the start-of-physics snapshot
+         cp_or_cv_dycore_at_start_of_physics_timestep (computed in d_p_coupling/
+         dyn_coupling_impl).
+         Any mid-physics mutation of cp_or_cv_dycore by thermo_water_update
+         should not be used.
          Then, perform the temperature and temperature tendency scaling -->
     <scheme>check_energy_scaling</scheme>
     <scheme>dycore_energy_consistency_adjust</scheme>

--- a/suites/suite_kessler.xml
+++ b/suites/suite_kessler.xml
@@ -31,17 +31,30 @@
   </group>
   <group name="physics_after_coupler">
 
-    <!-- Update cp/cv for energy computation based in updated water variables -->
-    <scheme>thermo_water_update</scheme>
+    <!-- thermo_water_update prepares cp_or_cv_dycore for post-physics
+         total-energy diagnostics (i.e., tot_energy_phys in CAM).
+         COMMENTED OUT: CAM-SIMA does not have tot_energy_phys diagnostics
+         yet, thus cp_or_cv_dycore does not need to be updated mid-physics
+         at this time.
+
+         check_energy_scaling reads cp_or_cv_dycore_at_start_of_physics_timestep
+         (computed in d_p_coupling/dyn_coupling_impl) instead
+         and should not use mid-physics timestep updated values (see CAM#1554).
+         Re-enable once dme_adjust is enabled and tot_energy_physics diagnostics
+         are implemented. -->
+    <!-- <scheme>thermo_water_update</scheme> -->
 
     <!-- COMMENTED OUT until qini/liqini/iceini have initialization routines -->
     <!-- See https://github.com/ESCOMP/atmospheric_physics/issues/222 -->
     <!-- <scheme>dme_adjust</scheme> -->
 
     <!-- MPAS and SE specific scaling of temperature for enforcing energy consistency:
-         First, calculate the scaling based off cp_or_cv_dycore (from cam_thermo_water_update)
-         Then, perform the temperature and temperature tendency scaling,
-         and apply tendencies resulting from such adjustment -->
+         First, calculate the scaling based off the start-of-physics snapshot
+         cp_or_cv_dycore_at_start_of_physics_timestep (computed in d_p_coupling/
+         dyn_coupling_impl).
+         Any mid-physics mutation of cp_or_cv_dycore by thermo_water_update
+         should not be used.
+         Then, perform the temperature and temperature tendency scaling -->
     <scheme>check_energy_scaling</scheme>
     <scheme>dycore_energy_consistency_adjust</scheme>
     <scheme>apply_tendency_of_air_temperature</scheme>

--- a/suites/suite_tj2016.xml
+++ b/suites/suite_tj2016.xml
@@ -24,17 +24,30 @@
     <scheme>apply_tendency_of_northward_wind</scheme>
     <scheme>qneg</scheme>
 
-    <!-- Update cp/cv for energy computation based in updated water variables -->
-    <scheme>thermo_water_update</scheme>
+    <!-- thermo_water_update prepares cp_or_cv_dycore for post-physics
+         total-energy diagnostics (i.e., tot_energy_phys in CAM).
+         COMMENTED OUT: CAM-SIMA does not have tot_energy_phys diagnostics
+         yet, thus cp_or_cv_dycore does not need to be updated mid-physics
+         at this time.
+
+         check_energy_scaling reads cp_or_cv_dycore_at_start_of_physics_timestep
+         (computed in d_p_coupling/dyn_coupling_impl) instead
+         and should not use mid-physics timestep updated values (see CAM#1554).
+         Re-enable once dme_adjust is enabled and tot_energy_physics diagnostics
+         are implemented. -->
+    <!-- <scheme>thermo_water_update</scheme> -->
 
     <!-- COMMENTED OUT until qini/liqini/iceini have initialization routines -->
     <!-- See https://github.com/ESCOMP/atmospheric_physics/issues/222 -->
     <!-- <scheme>dme_adjust</scheme> -->
 
     <!-- MPAS and SE specific scaling of temperature for enforcing energy consistency:
-         First, calculate the scaling based off cp_or_cv_dycore (from cam_thermo_water_update)
-         Then, perform the temperature and temperature tendency scaling,
-         and apply tendencies resulting from such adjustment -->
+         First, calculate the scaling based off the start-of-physics snapshot
+         cp_or_cv_dycore_at_start_of_physics_timestep (computed in d_p_coupling/
+         dyn_coupling_impl).
+         Any mid-physics mutation of cp_or_cv_dycore by thermo_water_update
+         should not be used.
+         Then, perform the temperature and temperature tendency scaling -->
     <scheme>check_energy_scaling</scheme>
     <scheme>dycore_energy_consistency_adjust</scheme>
     <scheme>apply_tendency_of_air_temperature</scheme>


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin (adapted from original fixes by @PeterHjortLauritzen)

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- CAM-SIMA equivalent of https://github.com/ESCOMP/CAM/pull/1554
- Add missing `thermo_water_update` call (although commented out as not used) in CAM4 SDF

List all namelist files that were added or changed:

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status main...<your_branch_name>`)
```
M       schemes/conservation_adjust/check_energy/check_energy_chng.meta
M       schemes/conservation_adjust/check_energy/check_energy_scaling.meta
M       schemes/conservation_adjust/check_energy/dycore_energy_consistency_adjust.meta
M       schemes/sima_diagnostics/check_energy_diagnostics.F90
M       schemes/sima_diagnostics/check_energy_diagnostics.meta
  - update cp_or_cv_dycore and scaling_dycore standard names to add _at_start_of_physics_timestep as correctly intended

M       suites/suite_cam7.xml
M       suites/suite_kessler.xml
M       suites/suite_tj2016.xml
  - comment out thermo_water_update as it is used for not-yet-present tot_energy_phys diag.
  - add comments explaining the true purpose of mid-physics thermo_water_update.

M       suites/suite_cam4.xml
  - add missing commented thermo_water_update call to be consistent with other SDFs
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

If yes to the above question, describe how this code was validated with the new/modified features:
