### PR TITLE
Prevent a segfault in ccpp tuvx wrapper

### DIFF
--- a/schemes/musica/tuvx/musica_ccpp_tuvx.F90
+++ b/schemes/musica/tuvx/musica_ccpp_tuvx.F90
@@ -558,7 +558,7 @@ contains
     real(kind_phys) :: reciprocal_of_gravitational_acceleration ! s2 m-1
     real(kind_phys) :: solar_zenith_angle_degrees
     type(error_t)   :: error
-    integer         :: i_col, i_level
+    integer         :: i_col, i_level, index
 
     reciprocal_of_gravitational_acceleration = 1.0_kind_phys / standard_gravitational_acceleration
 
@@ -629,8 +629,9 @@ contains
 
       ! map photolysis rate constants to the host model's rate parameters and vertical grid
       do i_level = 1, size(rate_parameters, dim=2)
+        index = size(rate_parameters, dim=2) - i_level + 2
         call photolysis_rate_constants_mapping%copy_data( &
-            photolysis_rate_constants(size(rate_parameters, dim=2)-i_level+2,:), &
+            photolysis_rate_constants(index,:), &
             rate_parameters(i_col,i_level,:) )
       end do
     end do


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): Kyle SHores

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):

In testing the terminator configuration of musica, I found with gcc 14.3.0, that the tuvx ccpp wrapper code would segfault. This is because the result of the `size(...)` call, and the math around it, was coming back either as zero or a negative number ( I can't remember which now). This results in a segfault. I guess this was the result of an overzealous optimizer path, or maybe some fortran language specification that I'm unaware of.

Either way, saving the math result to a local variable resolved the segfault.

List all namelist files that were added or changed:

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status main...<your_branch_name>`)

schemes/musica/tuvx/musica_ccpp_tuvx.F90

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

If yes to the above question, describe how this code was validated with the new/modified features:
