### PR TITLE
Change prescribed chemistry/aerosol schemes to use ccpp_scheme_utils; fully use diagnostic names in sima_state_diagnostics

### DIFF
--- a/schemes/chemistry/prescribed_aerosols.F90
+++ b/schemes/chemistry/prescribed_aerosols.F90
@@ -515,7 +515,7 @@ contains
       ! used as a negative array subscript below.
       if (const_idx < 0) then
         errflg = 1
-        errmsg = subname // ': could not find constituent ' // trim(aero_map_list(i)%constituent_name)
+        errmsg = subname // ': could not find constituent "' // trim(aero_map_list(i)%constituent_name)//'"'
         return
       end if
 

--- a/schemes/chemistry/prescribed_aerosols.F90
+++ b/schemes/chemistry/prescribed_aerosols.F90
@@ -457,7 +457,6 @@ contains
 !! \htmlinclude prescribed_aerosols_run.html
   subroutine prescribed_aerosols_run( &
     ncol, pver, pcnst, &
-    const_props, &
     pi, &
     pmid, pint, phis, zi, & ! necessary fields for trcdata read.
     constituents, &
@@ -469,17 +468,12 @@ contains
     ! host model dependency for history output
     use cam_history,               only: history_out_field
 
-    ! framework dependency for const_props
-    use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
-
-    ! dependency to get constituent index
-    use ccpp_const_utils,          only: ccpp_const_get_idx
+    ! framework dependency to get constituent index
+    use ccpp_scheme_utils,         only: ccpp_constituent_index
 
     integer,            intent(in)    :: ncol
     integer,            intent(in)    :: pver
     integer,            intent(in)    :: pcnst            ! # of CCPP constituents [count]
-    type(ccpp_constituent_prop_ptr_t), &
-                        intent(in)    :: const_props(:)   ! CCPP constituent properties pointer
     real(kind_phys),    intent(in)    :: pi
     real(kind_phys),    intent(in)    :: pmid(:,:)        ! air pressure [Pa]
     real(kind_phys),    intent(in)    :: pint(:,:)        ! air pressure at interfaces [Pa]
@@ -513,10 +507,17 @@ contains
     ! the logv and logm values read from tracer_data (port of rand_sample_prescribed_aero)
     do i = 1, aero_count
       ! Get constituent index
-      call ccpp_const_get_idx(const_props, &
-           trim(aero_map_list(i)%constituent_name), &
-           const_idx, errmsg, errflg)
+      call ccpp_constituent_index(trim(aero_map_list(i)%constituent_name), &
+           const_idx, errmsg=errmsg, errcode=errflg)
       if (errflg /= 0) return
+
+      ! Guard against an unresolved constituent index, which would otherwise be
+      ! used as a negative array subscript below.
+      if (const_idx < 0) then
+        errflg = 1
+        errmsg = subname // ': could not find constituent ' // trim(aero_map_list(i)%constituent_name)
+        return
+      end if
 
       if (.not. aero_map_list(i)%is_modal_aero_interstitial) then
         ! For non-interstitial species (cloud-borne or bulk aerosols),

--- a/schemes/chemistry/prescribed_aerosols.meta
+++ b/schemes/chemistry/prescribed_aerosols.meta
@@ -190,12 +190,6 @@
   type = integer
   dimensions = ()
   intent = in
-[ const_props ]
-  standard_name = ccpp_constituent_properties
-  units = none
-  type = ccpp_constituent_prop_ptr_t
-  dimensions = (number_of_ccpp_constituents)
-  intent = in
 [ pi ]
   standard_name = pi_constant
   units = 1

--- a/schemes/chemistry/prescribed_ozone.F90
+++ b/schemes/chemistry/prescribed_ozone.F90
@@ -153,7 +153,6 @@ contains
 !! \htmlinclude prescribed_ozone_run.html
   subroutine prescribed_ozone_run( &
     ncol, pver, &
-    const_props, &
     mwdry, boltz, &
     t, pmiddry, &
     pmid, pint, phis, zi, & ! necessary fields for trcdata read.
@@ -166,16 +165,11 @@ contains
     ! host model dependency for history output
     use cam_history, only: history_out_field
 
-    ! framework dependency for const_props
-    use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
-
-    ! dependency to get constituent index
-    use ccpp_const_utils,          only: ccpp_const_get_idx
+    ! framework dependency to get constituent index
+    use ccpp_scheme_utils,         only: ccpp_constituent_index
 
     integer,            intent(in)    :: ncol
     integer,            intent(in)    :: pver
-    type(ccpp_constituent_prop_ptr_t), &
-                        intent(in)    :: const_props(:)      ! CCPP constituent properties pointer
     real(kind_phys),    intent(in)    :: mwdry               ! molecular_weight_of_dry_air [g mol-1]
     real(kind_phys),    intent(in)    :: boltz               ! boltzmann_constant [J K-1]
     real(kind_phys),    intent(in)    :: t(:,:)              ! air temperature [K]
@@ -210,9 +204,8 @@ contains
 
     ! check for 'O3' constituent where prescribed ozone will be written to
     ! which will be read by radiation.
-    call ccpp_const_get_idx(const_props, &
-         trim(ozone_name), &
-         id_o3, errmsg, errflg)
+    call ccpp_constituent_index(trim(ozone_name), &
+         id_o3, errmsg=errmsg, errcode=errflg)
     if (errflg /= 0) return
 
     ! could not find the constituent, but the specifier is active.

--- a/schemes/chemistry/prescribed_ozone.meta
+++ b/schemes/chemistry/prescribed_ozone.meta
@@ -136,12 +136,6 @@
   type = integer
   dimensions = ()
   intent = in
-[ const_props ]
-  standard_name = ccpp_constituent_properties
-  units = none
-  type = ccpp_constituent_prop_ptr_t
-  dimensions = (number_of_ccpp_constituents)
-  intent = in
 [ mwdry ]
   standard_name = molecular_weight_of_dry_air
   units = g mol-1

--- a/schemes/sima_diagnostics/sima_state_diagnostics.F90
+++ b/schemes/sima_diagnostics/sima_state_diagnostics.F90
@@ -227,11 +227,11 @@ CONTAINS
       ! Capture all other constituent fields
       do const_idx = 1, size(const_props)
          if (.not. const_found(const_idx)) then
-            call const_props(const_idx)%standard_name(standard_name, errflg, errmsg)
+            ! Must match the name registered in sima_state_diagnostics_init.
+            call const_props(const_idx)%diagnostic_name(diagnostic_name, errflg, errmsg)
             if (errflg /= 0) then
                return
             end if
-            diagnostic_name = standard_name
             call history_out_field(trim(diagnostic_name), const_array(:,:,const_idx))
          end if
       end do


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin 

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Change prescribed chemistry/aerosol schemes to use ccpp_scheme_utils so they are case-insensitive - companion PR to https://github.com/ESCOMP/CAM-SIMA/pull/518
- #397 (in 979c6bca02a4e4c76d94205c27831a7be66fb035) changed `sima_state_diagnostics` to use `%diagnostic_name` to add field but not the write loop, so if the two cases mismatched (due to the case-insensitivity fixes they now do) the `history_out_field` would be mismatched and would write uninitialized heap memory into the netCDF file rather than the variable.

List all namelist files that were added or changed:

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status main...<your_branch_name>`)
```
M       schemes/chemistry/prescribed_aerosols.F90
M       schemes/chemistry/prescribed_aerosols.meta
M       schemes/chemistry/prescribed_ozone.F90
M       schemes/chemistry/prescribed_ozone.meta
  - change to use ccpp_scheme_utils.
 
M       schemes/sima_diagnostics/sima_state_diagnostics.F90
  - change to use diagnostic_name in history_out_field.
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

If yes to the above question, describe how this code was validated with the new/modified features:
