### PR TITLE
Persist LW/SW fluxes across non-radiation timesteps

### DIFF
--- a/schemes/rrtmgp/rrtmgp_lw_calculate_fluxes.F90
+++ b/schemes/rrtmgp/rrtmgp_lw_calculate_fluxes.F90
@@ -12,7 +12,7 @@ CONTAINS
    !> \section arg_table_rrtmgp_lw_calculate_fluxes_run  Argument Table
    !! \htmlinclude rrtmgp_lw_calculate_fluxes_run.html
    subroutine rrtmgp_lw_calculate_fluxes_run(num_diag_subcycles, icall, ncol, pverp, nlay, ktopcam, ktoprad, &
-      active_calls, flw, flwc, flns, flnt, flwds, fnl, fcnl, errmsg, errflg)
+      active_calls, dolw, flw, flwc, flns, flnt, flwds, fnl, fcnl, errmsg, errflg)
 
       use ccpp_fluxes,        only: ty_fluxes_broadband_ccpp
       use ccpp_fluxes_byband, only: ty_fluxes_byband_ccpp
@@ -27,14 +27,15 @@ CONTAINS
       integer,                        intent(in) :: ktopcam             ! Index in host model arrays of top level (layer or interface) at which RRTMGP is active
       integer,                        intent(in) :: ktoprad             ! Index in RRTMGP array corresponding to top layer or interface of host model arrays
       logical,                        intent(in) :: active_calls(:)     ! Logical array of flags for whether a specified subcycle is active
+      logical,                        intent(in) :: dolw                ! Flag for whether to perform longwave calculation
       type(ty_fluxes_byband_ccpp),    intent(in) :: flw                 ! Longwave all-sky flux object
       type(ty_fluxes_broadband_ccpp), intent(in) :: flwc                ! Longwave clear-sky flux object
       ! Output variables
-      real(kind_phys),               intent(out) :: fnl(:,:)            ! Longwave net radiative flux [W m-2]
-      real(kind_phys),               intent(out) :: fcnl(:,:)           ! Longwave net radiative clear-sky flux [W m-2]
-      real(kind_phys),               intent(out) :: flns(:)             ! Longwave net upward flux at surface [W m-2]
-      real(kind_phys),               intent(out) :: flnt(:)             ! Longwave net outgoing flux at model top [W m-2]
-      real(kind_phys),               intent(out) :: flwds(:)            ! Longwave downward radiative flux at surface [W m-2]
+      real(kind_phys),             intent(inout) :: fnl(:,:)            ! Longwave net radiative flux [W m-2]
+      real(kind_phys),             intent(inout) :: fcnl(:,:)           ! Longwave net radiative clear-sky flux [W m-2]
+      real(kind_phys),             intent(inout) :: flns(:)             ! Longwave net upward flux at surface [W m-2]
+      real(kind_phys),             intent(inout) :: flnt(:)             ! Longwave net outgoing flux at model top [W m-2]
+      real(kind_phys),             intent(inout) :: flwds(:)            ! Longwave downward radiative flux at surface [W m-2]
 
       
       ! CCPP error handling variables
@@ -46,6 +47,11 @@ CONTAINS
 
       errmsg = ''
       errflg = 0
+
+      ! Persist fluxes from the last radiation timestep in non-radiation timesteps:
+      if (.not. dolw) then
+         return
+      end if
 
       diag_index = num_diag_subcycles - icall + 1
 

--- a/schemes/rrtmgp/rrtmgp_lw_calculate_fluxes.meta
+++ b/schemes/rrtmgp/rrtmgp_lw_calculate_fluxes.meta
@@ -78,7 +78,7 @@
   dimensions = (horizontal_loop_extent)
   intent = out
 [ flwds ]
-  standard_name = longwave_downward_radiative_flux_at_surface
+  standard_name = longwave_downward_radiative_flux_at_surface_to_coupler
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)

--- a/schemes/rrtmgp/rrtmgp_lw_calculate_fluxes.meta
+++ b/schemes/rrtmgp/rrtmgp_lw_calculate_fluxes.meta
@@ -53,6 +53,12 @@
   type = logical
   dimensions = (number_of_diagnostic_subcycles)
   intent = in
+[ dolw ]
+  standard_name = do_longwave_radiation
+  units = flag
+  type = logical
+  dimensions = ()
+  intent = in
 [ flw ]
   standard_name = longwave_all_sky_flux_object_for_RRTMGP
   units = none
@@ -70,31 +76,31 @@
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ flnt ]
   standard_name = longwave_net_outgoing_flux_at_model_top
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ flwds ]
   standard_name = longwave_downward_radiative_flux_at_surface_to_coupler
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ fnl ]
   standard_name = longwave_net_radiative_flux
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
-  intent = out
+  intent = inout
 [ fcnl ]
   standard_name = longwave_net_radiative_clear_sky_flux
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
-  intent = out
+  intent = inout
 [ errmsg ]
   standard_name = ccpp_error_message
   units = none

--- a/schemes/rrtmgp/rrtmgp_post.meta
+++ b/schemes/rrtmgp/rrtmgp_post.meta
@@ -108,7 +108,7 @@
   dimensions = ()
   intent = inout
 [ flwds ]
-  standard_name = longwave_downward_radiative_flux_at_surface
+  standard_name = longwave_downward_radiative_flux_at_surface_to_coupler
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
@@ -126,7 +126,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = out
 [ netsw ]
-  standard_name = net_shortwave_flux_at_surface
+  standard_name = net_shortwave_flux_at_surface_to_coupler
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)

--- a/schemes/rrtmgp/rrtmgp_sw_calculate_fluxes.F90
+++ b/schemes/rrtmgp/rrtmgp_sw_calculate_fluxes.F90
@@ -12,7 +12,7 @@ CONTAINS
    !> \section arg_table_rrtmgp_sw_calculate_fluxes_run  Argument Table
    !! \htmlinclude rrtmgp_sw_calculate_fluxes_run.html
    subroutine rrtmgp_sw_calculate_fluxes_run(num_diag_subcycles, icall, ncol, pverp, nlay, nday, idxday, ktopcam, ktoprad, &
-      active_calls, fsw, fswc, fns, fcns, fsns, fsnt, soll, sols, solld, solsd, errmsg, errflg)
+      active_calls, dosw, fsw, fswc, fns, fcns, fsns, fsnt, soll, sols, solld, solsd, errmsg, errflg)
 
       use ccpp_fluxes,        only: ty_fluxes_broadband_ccpp
       use ccpp_fluxes_byband, only: ty_fluxes_byband_ccpp
@@ -29,17 +29,18 @@ CONTAINS
       integer,                        intent(in) :: ktoprad             ! Index in RRTMGP array corresponding to top layer or interface of host model arrays
       integer,                        intent(in) :: idxday(:)           ! Daytime points indices
       logical,                        intent(in) :: active_calls(:)     ! Logical array of flags for whether a specified subcycle is active
+      logical,                        intent(in) :: dosw                ! Flag for whether to perform shortwave calculation
       type(ty_fluxes_byband_ccpp),    intent(in) :: fsw                 ! Shortwave all-sky flux object
       type(ty_fluxes_broadband_ccpp), intent(in) :: fswc                ! Shortwave clear-sky flux object
       ! Output variables
-      real(kind_phys),               intent(out) :: fns(:,:)            ! Shortwave net radiative flux [W m-2]
-      real(kind_phys),               intent(out) :: fcns(:,:)           ! Shortwave net radiative clear-sky flux [W m-2]
-      real(kind_phys),               intent(out) :: fsns(:)             ! Shortwave net upward flux at surface [W m-2]
-      real(kind_phys),               intent(out) :: fsnt(:)             ! Shortwave net outgoing flux at model top [W m-2]
-      real(kind_phys),               intent(out) :: soll(:)             ! Direct solar radiative flux at surface >= 700nm [W m-2]
-      real(kind_phys),               intent(out) :: sols(:)             ! Direct solar radiative flux at surface < 700nm [W m-2]
-      real(kind_phys),               intent(out) :: solld(:)            ! Diffuse solar radiative flux at surface >= 700nm [W m-2]
-      real(kind_phys),               intent(out) :: solsd(:)            ! Diffuse solar radiative flux at surface < 700nm [W m-2]
+      real(kind_phys),             intent(inout) :: fns(:,:)            ! Shortwave net radiative flux [W m-2]
+      real(kind_phys),             intent(inout) :: fcns(:,:)           ! Shortwave net radiative clear-sky flux [W m-2]
+      real(kind_phys),             intent(inout) :: fsns(:)             ! Shortwave net upward flux at surface [W m-2]
+      real(kind_phys),             intent(inout) :: fsnt(:)             ! Shortwave net outgoing flux at model top [W m-2]
+      real(kind_phys),             intent(inout) :: soll(:)             ! Direct solar radiative flux at surface >= 700nm [W m-2]
+      real(kind_phys),             intent(inout) :: sols(:)             ! Direct solar radiative flux at surface < 700nm [W m-2]
+      real(kind_phys),             intent(inout) :: solld(:)            ! Diffuse solar radiative flux at surface >= 700nm [W m-2]
+      real(kind_phys),             intent(inout) :: solsd(:)            ! Diffuse solar radiative flux at surface < 700nm [W m-2]
 
       
       ! CCPP error handling variables
@@ -54,6 +55,11 @@ CONTAINS
 
       errmsg = ''
       errflg = 0
+
+      ! Persist fluxes from the last radiation timestep in non-radiation timesteps:
+      if (.not. dosw) then
+         return
+      end if
 
       diag_index = num_diag_subcycles - icall + 1
 

--- a/schemes/rrtmgp/rrtmgp_sw_calculate_fluxes.meta
+++ b/schemes/rrtmgp/rrtmgp_sw_calculate_fluxes.meta
@@ -65,6 +65,12 @@
   type = logical
   dimensions = (number_of_diagnostic_subcycles)
   intent = in
+[ dosw ]
+  standard_name = do_shortwave_radiation
+  units = flag
+  type = logical
+  dimensions = ()
+  intent = in
 [ fsw ]
   standard_name = shortwave_all_sky_flux_object_for_RRTMGP
   units = none
@@ -82,49 +88,49 @@
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
-  intent = out
+  intent = inout
 [ fcns ]
   standard_name = shortwave_net_radiative_clear_sky_flux
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
-  intent = out
+  intent = inout
 [ fsns ]
   standard_name = shortwave_net_upward_flux_at_surface
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ fsnt ]
   standard_name = shortwave_net_outgoing_flux_at_model_top
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ soll ]
   standard_name = direct_solar_radiative_flux_at_surface_ge_700nm_to_coupler
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ sols ]
   standard_name = direct_solar_radiative_flux_at_surface_lt_700nm_to_coupler
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ solld ]
   standard_name = diffuse_solar_radiative_flux_at_surface_ge_700nm_to_coupler
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ solsd ]
   standard_name = diffuse_solar_radiative_flux_at_surface_lt_700nm_to_coupler
   units = W m-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
-  intent = out
+  intent = inout
 [ errmsg ]
   standard_name = ccpp_error_message
   units = none


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin 

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Companion PR to https://github.com/ESCOMP/CAM-SIMA/pull/527
- Persists LW/SW fluxes even in non-radiation timesteps consistent with CAM
- Fixes standard name (missing `_to_coupler`) from post-interstitial

List all namelist files that were added or changed:

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status main...<your_branch_name>`)
```
M       schemes/rrtmgp/rrtmgp_lw_calculate_fluxes.F90
M       schemes/rrtmgp/rrtmgp_lw_calculate_fluxes.meta
M       schemes/rrtmgp/rrtmgp_sw_calculate_fluxes.F90
M       schemes/rrtmgp/rrtmgp_sw_calculate_fluxes.meta
  - Persists LW/SW fluxes even in non-radiation timesteps consistent with CAM

M       schemes/rrtmgp/rrtmgp_post.meta
  - add _to_coupler suffix to standard name to pass the fluxes to the coupler.
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

If yes to the above question, describe how this code was validated with the new/modified features:
