### PR TITLE
Mods needed to run CAM4 F-compset (AMIP) configurations

### DIFF
--- a/schemes/rasch_kristjansson/rk_stratiform.F90
+++ b/schemes/rasch_kristjansson/rk_stratiform.F90
@@ -5,7 +5,6 @@ module rk_stratiform
 
   implicit none
   private
-  save
 
   ! public CCPP-compliant subroutines
   !   note: cloud_fraction_perturbation_run calls the compute_cloud_fraction
@@ -459,6 +458,15 @@ contains
 
    prec_str(:ncol) = prec_str(:ncol) + prec_pcw(:ncol)
    snow_str(:ncol) = snow_str(:ncol) + snow_pcw(:ncol)
+
+   ! RK can occassionally produce negative precipitation fluxes, so force
+   ! it to be greater than or equal to zero.  Also ensure that snow is not
+   ! greater than the total precipitation. This is a non-physical adjustment,
+   ! but is the same technique that the original CAM4 model used:
+   do i = 1, ncol
+      if (prec_str(i) < 0._kind_phys) prec_str(i) = 0._kind_phys
+      if (snow_str(i) > prec_str(i))  snow_str(i) = prec_str(i)
+   end do
 
   end subroutine rk_stratiform_prognostic_cloud_water_tendencies_run
 

--- a/schemes/rrtmgp/rrtmgp_constituents_namelist.xml
+++ b/schemes/rrtmgp/rrtmgp_constituents_namelist.xml
@@ -95,7 +95,7 @@
         'N:CFC11STAR:CFC11',
         'A:CFC12:CFC12'
       </value>
-      <value aquaplanet="1" phys_suite="cam4">
+      <value phys_suite="cam4">
         'N:O2:O2',
         'N:CO2:CO2',
         'N:ozone:O3',


### PR DESCRIPTION
Tag name (The PR title should also include the tag name): atmos_phys0_28_001
Originator(s): nusbaume  (Claude Opus 5 helped find the issues).

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):

Added some code modifications needed for the CAM4 + BAM physics/chemistry suite to run stably in an F-compset (i.e. AMIP or prescribed SSTs/sea ice) configuration.

List all namelist files that were added or changed:

M       schemes/rrtmgp/rrtmgp_constituents_namelist.xml
 - Removed aquaplanet flag when setting radiatively active gases (which should eventually be managed by the chemistry scheme anyways, see #435).

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status main...<your_branch_name>`)

M       schemes/rasch_kristjansson/rk_stratiform.F90
 - Add fixer for negative surface precipitation, which matches what is done in CAM.

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? 

Yes, the RK precipitation adjustment results in answer differences.

If yes to the above question, describe how this code was validated with the new/modified features:  

I did a five year run and looked at the results.
