### PR TITLE
Add sim_year namelist default values for 1850 (pre-industrial)

### DIFF
--- a/schemes/chemistry/prescribed_aerosol_deposition_flux_namelist.xml
+++ b/schemes/chemistry/prescribed_aerosol_deposition_flux_namelist.xml
@@ -100,6 +100,8 @@
     </desc>
     <values>
       <value>aerosoldep_monthly_1849-2006_1.9x2.5_c090803.nc</value>
+      <!-- pre-industrial (1850) climatology -->
+      <value sim_year="1850">aerosoldep_monthly_1850_mean_1.9x2.5_c090421.nc</value>
       <!-- aquaplanet runs without aerosols -->
       <value aquaplanet="1">''</value>
     </values>
@@ -167,6 +169,7 @@
     </desc>
     <values>
       <value>2000</value>
+      <value sim_year="1850">1850</value>
     </values>
   </entry>
 

--- a/schemes/chemistry/prescribed_aerosols_namelist.xml
+++ b/schemes/chemistry/prescribed_aerosols_namelist.xml
@@ -124,6 +124,7 @@
     </desc>
     <values>
       <value>aero_1.9x2.5_L26_2000clim_c091112.nc</value>
+      <value sim_year="1850">aero_1.9x2.5_L26_1850clim_c091112.nc</value>
       <!-- mam: mam3_1.9x2.5_L30_2000clim_c130319.nc -->
       <!-- aquaplanet runs without aerosols -->
       <value aquaplanet="1">''</value>
@@ -198,6 +199,7 @@
     </desc>
     <values>
       <value>2000</value>
+      <value sim_year="1850">1850</value>
     </values>
   </entry>
 

--- a/schemes/chemistry/prescribed_ozone_namelist.xml
+++ b/schemes/chemistry/prescribed_ozone_namelist.xml
@@ -100,6 +100,7 @@
     </desc>
     <values>
       <value>ozone_1.9x2.5_L26_2000clim_c091112.nc</value>
+      <value sim_year="1850">ozone_1.9x2.5_L26_1850clim_c091112.nc</value>
       <!-- aquaplanet uses the zonally symmetric APE ozone file -->
       <value aquaplanet="1">apeozone_cam3_5_54.nc</value>
     </values>
@@ -162,6 +163,7 @@
     </desc>
     <values>
       <value>2000</value>
+      <value sim_year="1850">1850</value>
       <!-- cycle year of the APE ozone file -->
       <value aquaplanet="1">1990</value>
     </values>

--- a/schemes/radiation_utils/prescribe_radiative_gas_concentrations_namelist.xml
+++ b/schemes/radiation_utils/prescribe_radiative_gas_concentrations_namelist.xml
@@ -88,6 +88,7 @@
     </desc>
     <values>
       <value>1760.0e-9</value>
+      <value sim_year="1850">791.6e-9</value>
       <value aquaplanet="1" phys_suite="cam4">1650.0e-9</value>
     </values>
   </entry>
@@ -104,6 +105,7 @@
     </desc>
     <values>
       <value>367.0e-6</value>
+      <value sim_year="1850">284.7e-6</value>
       <value aquaplanet="1" phys_suite="cam4">348.0e-6</value>
     </values>
   </entry>
@@ -120,6 +122,7 @@
     </desc>
     <values>
       <value>653.45e-12</value>
+      <value sim_year="1850">12.48e-12</value>
     </values>
   </entry>
   <entry id="prescribed_cfc12_vmr">
@@ -135,6 +138,7 @@
     </desc>
     <values>
       <value>535.0e-12</value>
+      <value sim_year="1850">0.0</value>
     </values>
   </entry>
   <entry id="prescribed_n2o_vmr">
@@ -150,6 +154,7 @@
     </desc>
     <values>
       <value>316.0e-9</value>
+      <value sim_year="1850">275.68e-9</value>
       <value aquaplanet="1" phys_suite="cam4">306.0e-9</value>
     </values>
   </entry>

--- a/schemes/radiation_utils/solar_irradiance_data_namelist.xml
+++ b/schemes/radiation_utils/solar_irradiance_data_namelist.xml
@@ -129,6 +129,7 @@
     </desc>
     <values>
       <value>20000101</value>
+      <value sim_year="1850">18500101</value>
     </values>
   </entry>
   <entry id="solar_data_tod">


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin verified by `claude-opus-5`

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Add defaults for `sim_year = 1850`. This attribute requires https://github.com/ESCOMP/CAM-SIMA/pull/545 companion PR.

List all namelist files that were added or changed:
```
M       schemes/chemistry/prescribed_aerosol_deposition_flux_namelist.xml
M       schemes/chemistry/prescribed_aerosols_namelist.xml
M       schemes/chemistry/prescribed_ozone_namelist.xml
M       schemes/radiation_utils/prescribe_radiative_gas_concentrations_namelist.xml
M       schemes/radiation_utils/solar_irradiance_data_namelist.xml
  - populate 1850 defaults 
```

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status main...<your_branch_name>`)

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

Yes, F1850 update

If yes to the above question, describe how this code was validated with the new/modified features:
