### PR TITLE
atmos_phys0_28_03: Fix missing _r8 and update PUMAS external

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	path = schemes/pumas/pumas
 	url = https://github.com/ESCOMP/PUMAS
         fxrequired = AlwaysRequired
-        fxtag = pumas_cam-release_v1.40
+        fxtag = pumas_cam-release_v1.41
         fxDONOTUSEurl = https://github.com/ESCOMP/PUMAS
 [submodule "rte-rrtmgp"]
 	path = schemes/rrtmgp/ext

--- a/schemes/gravity_wave_drag/gravity_wave_drag_moving_mountain.F90
+++ b/schemes/gravity_wave_drag/gravity_wave_drag_moving_mountain.F90
@@ -739,7 +739,7 @@ contains
         end if ! heating depth above min and not at the pole
       else
         !  ----  Assign source momentum flux for gw_drag_prof.
-        tau(i,0,topi(i)+1 ) = xpwp_src(i) 
+        tau(i,0,topi(i)+1 ) = xpwp_src(i)
       end if
 
     end do
@@ -793,7 +793,7 @@ contains
     steering_level(:ncol) = pverx - 20
     launch_level(:ncol) = steering_level - 10
 
-    scale_factor = 1.e4 ! scales vorticity amp to u'w' in CLUBB
+    scale_factor = 1.e4_r8 ! scales vorticity amp to u'w' in CLUBB
     !-----------------------------------
     ! Simple average over layers.
     ! Probably can do better


### PR DESCRIPTION
Tag name (The PR title should also include the tag name): atmos_phys0_28_03
Originator(s): cacraigucar

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
  - Fix missing _r8 and bring in updated PUMAS external with the required fixes

List all namelist files that were added or changed: N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status main...<your_branch_name>`)
M       .gitmodules
M       schemes/pumas/pumas
              - update atmospheric_physics external
              
M       schemes/gravity_wave_drag/gravity_wave_drag_moving_mountain.F90
              - Fix missing _r8 

List all automated tests that failed, as well as an explanation for why they weren't fixed:  All pass

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc? no

If yes to the above question, describe how this code was validated with the new/modified features:
