### PR TITLE
Various fixes for MUSICA; split TUV-x and MICM into separate CCPP schemes

### DIFF
--- a/schemes/musica/micm/musica_ccpp_micm.F90
+++ b/schemes/musica/micm/musica_ccpp_micm.F90
@@ -253,7 +253,7 @@ contains
       end if
 
       ! Update the mixing ratios with the results
-      call extract_mixing_ratios_from_state( state, offset, mixing_ratios)
+      call extract_mixing_ratios_from_state( state, offset, dry_air_density, mixing_ratios)
 
     end do
 

--- a/schemes/musica/micm/musica_ccpp_micm_util.F90
+++ b/schemes/musica/micm/musica_ccpp_micm_util.F90
@@ -59,8 +59,10 @@ contains
     do i_var = 1, state%number_of_species
       species_1D(1:n_cells_total) => mixing_ratios(:,:,micm_indices_constituent_props(i_var))
       do i_cell = 1, n_cells
+        ! MMR (kg kg-1) -> concentration (mol m-3): multiply by the dry air *mass*
+        ! density (kg m-3), not the molar density stored in conditions%air_density
         state%concentrations( 1 + ( i_cell - 1 ) * cell_stride + ( i_var - 1 ) * var_stride ) = &
-          species_1D(i_cell + state_data_offset) * state%conditions(i_cell)%air_density &
+          species_1D(i_cell + state_data_offset) * air_density_1D(i_cell + state_data_offset) &
               / micm_molar_mass_array(i_var)
       end do
     end do
@@ -86,21 +88,25 @@ contains
   !! CCPP constituent ordering. The concentrations are converted to mass mixing
   !! ratios (kg kg-1) using the dry air density and molecular weights of the
   !! species.
-  subroutine extract_mixing_ratios_from_state(state, state_data_offset, mixing_ratios)
+  subroutine extract_mixing_ratios_from_state(state, state_data_offset, dry_air_mass_density, &
+                                              mixing_ratios)
 
     use musica_ccpp_species, only: micm_indices_constituent_props, micm_molar_mass_array
     use musica_state,        only: state_t
 
     type(state_t),                       intent(in)    :: state
-    integer,                             intent(in)    :: state_data_offset    ! number of grid cells already updated
-    real(kind_phys), target, contiguous, intent(inout) :: mixing_ratios(:,:,:) ! kg kg-1 (column, layer, species)
+    integer,                             intent(in)    :: state_data_offset         ! number of grid cells already updated
+    real(kind_phys), target, contiguous, intent(in)    :: dry_air_mass_density(:,:) ! kg m-3 (column, layer)
+    real(kind_phys), target, contiguous, intent(inout) :: mixing_ratios(:,:,:)      ! kg kg-1 (column, layer, species)
 
     integer :: i_cell, i_var, state_offset, n_cells, n_cells_total
-    real(kind_phys), pointer :: species_1D(:)
+    real(kind_phys), pointer :: species_1D(:), air_density_1D(:)
 
     ! get grid cell dimensions
     n_cells = state%number_of_grid_cells
     n_cells_total = size(mixing_ratios, 1) * size(mixing_ratios, 2)
+
+    air_density_1D(1:n_cells_total) => dry_air_mass_density(:,:)
 
     ! Update species mass mixing ratios
     associate(cell_stride => state%species_strides%grid_cell, &
@@ -108,9 +114,11 @@ contains
     do i_var = 1, state%number_of_species
       species_1D(1:n_cells_total) => mixing_ratios(:,:,micm_indices_constituent_props(i_var))
       do i_cell = 1, n_cells
+        ! concentration (mol m-3) -> MMR (kg kg-1): divide by the dry air *mass*
+        ! density (kg m-3); exact inverse of the conversion in update_micm_state
         species_1D(i_cell + state_data_offset) = &
           state%concentrations( 1 + ( i_cell - 1 ) * cell_stride + ( i_var - 1 ) * var_stride ) &
-          * micm_molar_mass_array(i_var) / state%conditions(i_cell)%air_density
+          * micm_molar_mass_array(i_var) / air_density_1D(i_cell + state_data_offset)
       end do
     end do
     end associate

--- a/schemes/musica/musica_ccpp.F90
+++ b/schemes/musica/musica_ccpp.F90
@@ -55,8 +55,12 @@ contains
     end if
 
     call register_musica_species(micm_species, tuvx_species)
-    call check_tuvx_species_initialization(errmsg, errcode)
-    if (errcode /= 0) return
+    ! The TUV-x species indices are only assigned by tuvx_register, so they
+    ! can only be validated when TUV-x is enabled
+    if (do_tuvx) then
+      call check_tuvx_species_initialization(errmsg, errcode)
+      if (errcode /= 0) return
+    end if
 
   end subroutine musica_ccpp_register
 
@@ -179,6 +183,11 @@ contains
     call extract_subset_constituents(tuvx_indices_constituent_props, constituents, &
                                      constituents_tuvx_species, errmsg, errcode)
     if (errcode /= 0) return
+
+    ! Zero all rate parameters: TUV-x only writes the mapped photolysis slots,
+    ! so unmapped slots (and every slot when TUV-x is disabled) would otherwise
+    ! be uninitialized memory. Zero means the corresponding reaction is off.
+    rate_parameters(:,:,:) = 0.0_kind_phys
 
     ! Calculate photolysis rate constants using TUV-x
     if (do_tuvx) then

--- a/schemes/musica/musica_ccpp.F90
+++ b/schemes/musica/musica_ccpp.F90
@@ -3,32 +3,33 @@
 
 !> Top-level wrapper for MUSICA chemistry components
 module musica_ccpp
-  use musica_ccpp_micm,     only: micm_register, micm_init, micm_run, micm_final
+  use musica_ccpp_micm,     only: micm_register, micm_init, micm_final
   use musica_ccpp_namelist, only: filename_of_tuvx_micm_mapping_configuration
-  use musica_ccpp_tuvx,     only: tuvx_register, tuvx_init, tuvx_run, tuvx_final
+  use musica_ccpp_tuvx,     only: tuvx_register, tuvx_init, tuvx_final
+  use musica_ccpp_util,     only: do_tuvx
   use musica_util,          only: index_mappings_t
 
   implicit none
   private
   save
 
-  public :: musica_ccpp_register, musica_ccpp_init, musica_ccpp_run, musica_ccpp_final
-
-  integer :: number_of_micm_rate_parameters = -1
-
-  logical, public, protected :: do_tuvx = .false.
+  public :: musica_ccpp_register, musica_ccpp_init, musica_ccpp_final
 
 contains
 
   !> \section arg_table_musica_ccpp_register Argument Table
   !! \htmlinclude musica_ccpp_register.html
-  subroutine musica_ccpp_register(constituent_props, errmsg, errcode)
+  subroutine musica_ccpp_register(constituent_props, number_of_micm_rate_parameters, &
+                                  errmsg, errcode)
     use ccpp_constituent_prop_mod,     only: ccpp_constituent_properties_t
+    use musica_ccpp_micm,              only: rate_parameters_ordering
     use musica_ccpp_namelist,          only: micm_solver_type, filename_of_tuvx_configuration
     use musica_ccpp_species,           only: musica_species_t, register_musica_species
     use musica_ccpp_tuvx_load_species, only: check_tuvx_species_initialization
+    use musica_ccpp_util,              only: set_do_tuvx
 
     type(ccpp_constituent_properties_t), allocatable, intent(out) :: constituent_props(:)
+    integer,                                          intent(out) :: number_of_micm_rate_parameters
     character(len=512),                               intent(out) :: errmsg
     integer,                                          intent(out) :: errcode
 
@@ -43,14 +44,25 @@ contains
     constituent_props = constituent_props_subset
     deallocate(constituent_props_subset)
 
+    ! Export the number of MICM rate parameters (photolysis, user-defined,
+    ! emission, loss, and surface reaction parameters) so the framework can
+    ! size the rate parameter array shared by the photolysis and chemistry
+    ! run schemes
+    number_of_micm_rate_parameters = rate_parameters_ordering%size()
+    if (number_of_micm_rate_parameters < 0) then
+      errmsg = "[MUSICA Error] Internal error: number_of_micm_rate_parameters < 0"
+      errcode = 1
+      return
+    end if
+
     if (trim(filename_of_tuvx_configuration) /= "none") then
-      do_tuvx = .true.
+      call set_do_tuvx(.true.)
       call tuvx_register(micm_species, tuvx_species, constituent_props_subset, &
                          errmsg, errcode)
       if (errcode /= 0) return
       constituent_props = [ constituent_props, constituent_props_subset ]
     else
-      do_tuvx = .false.
+      call set_do_tuvx(.false.)
       allocate(tuvx_species(0))
     end if
 
@@ -100,12 +112,6 @@ contains
 
     call micm_init(number_of_grid_cells, errmsg, errcode)
     if (errcode /= 0) return
-    number_of_micm_rate_parameters = rate_parameters_ordering%size()
-    if (number_of_micm_rate_parameters < 0) then
-      errmsg = "MUSICA: Internal error: number_of_micm_rate_parameters < 0"
-      errcode = 1
-      return
-    end if
 
     if (do_tuvx) then
       if (size(photolysis_wavelength_grid_interfaces) < 2) then
@@ -131,89 +137,6 @@ contains
     if (errcode /= 0) return
 
   end subroutine musica_ccpp_init
-
-  !> \section arg_table_musica_ccpp_run Argument Table
-  !! \htmlinclude musica_ccpp_run.html
-  !!
-  !! The standard name for the variable 'surface_temperature' is
-  !! 'blackbody_temperature_at_surface' as this is the standard name
-  !! used for 'cam_in%ts,' which represents the same quantity.
-  subroutine musica_ccpp_run(time_step, temperature, pressure, dry_air_density, constituent_props, &
-                             constituents, geopotential_height_wrt_surface_at_midpoint,            &
-                             geopotential_height_wrt_surface_at_interface, surface_geopotential,   &
-                             surface_temperature, surface_albedo, extraterrestrial_flux,           &
-                             standard_gravitational_acceleration, cloud_area_fraction,             &
-                             air_pressure_thickness, solar_zenith_angle, earth_sun_distance,       &
-                             log_output_unit, errmsg, errcode)
-    use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
-    use ccpp_kinds,                only: kind_phys
-    use musica_ccpp_species,       only: number_of_tuvx_species, tuvx_indices_constituent_props, &
-                                         extract_subset_constituents
-
-    real(kind_phys),         intent(in)    :: time_step                                         ! s
-    real(kind_phys), target, intent(in)    :: temperature(:,:)                                  ! K (column, layer)
-    real(kind_phys), target, intent(in)    :: pressure(:,:)                                     ! Pa (column, layer)
-    real(kind_phys), target, intent(in)    :: dry_air_density(:,:)                              ! kg m-3 (column, layer)
-    type(ccpp_constituent_prop_ptr_t), &
-                             intent(in)    :: constituent_props(:)                              ! (constituent)
-    real(kind_phys), target, intent(inout) :: constituents(:,:,:)                               ! kg kg-1 (column, layer, constituent)
-    real(kind_phys),         intent(in)    :: geopotential_height_wrt_surface_at_midpoint(:,:)  ! m (column, layer)
-    real(kind_phys),         intent(in)    :: geopotential_height_wrt_surface_at_interface(:,:) ! m (column, interface)
-    real(kind_phys),         intent(in)    :: surface_geopotential(:)                           ! m2 s-2 (column)
-    real(kind_phys),         intent(in)    :: surface_temperature(:)                            ! K (column)
-    real(kind_phys),         intent(in)    :: surface_albedo(:)                                 ! fraction (column)
-    real(kind_phys),         intent(in)    :: extraterrestrial_flux(:)                          ! photons cm-2 s-1 nm-1 (wavelength interface)
-    real(kind_phys),         intent(in)    :: standard_gravitational_acceleration               ! m s-2
-    real(kind_phys),         intent(in)    :: cloud_area_fraction(:,:)                          ! fraction (column, layer)
-    real(kind_phys),         intent(in)    :: air_pressure_thickness(:,:)                       ! Pa (column, layer)
-    real(kind_phys),         intent(in)    :: solar_zenith_angle(:)                             ! radians (column)
-    real(kind_phys),         intent(in)    :: earth_sun_distance                                ! AU
-    integer,                 intent(in)    :: log_output_unit                                   ! file unit number for logging
-    character(len=512),      intent(out)   :: errmsg
-    integer,                 intent(out)   :: errcode
-
-    ! local variables
-    real(kind_phys), dimension(size(constituents, dim=1), &
-                               size(constituents, dim=2), &
-                               number_of_micm_rate_parameters) :: rate_parameters ! various units
-    real(kind_phys), dimension(size(constituents, dim=1), &
-                               size(constituents, dim=2), &
-                               number_of_tuvx_species)         :: constituents_tuvx_species ! kg kg-1
-
-    call extract_subset_constituents(tuvx_indices_constituent_props, constituents, &
-                                     constituents_tuvx_species, errmsg, errcode)
-    if (errcode /= 0) return
-
-    ! Zero all rate parameters: TUV-x only writes the mapped photolysis slots,
-    ! so unmapped slots (and every slot when TUV-x is disabled) would otherwise
-    ! be uninitialized memory. Zero means the corresponding reaction is off.
-    rate_parameters(:,:,:) = 0.0_kind_phys
-
-    ! Calculate photolysis rate constants using TUV-x
-    if (do_tuvx) then
-      call tuvx_run(temperature, dry_air_density,                 &
-                    constituents_tuvx_species,                    &
-                    geopotential_height_wrt_surface_at_midpoint,  &
-                    geopotential_height_wrt_surface_at_interface, &
-                    surface_geopotential, surface_temperature,    &
-                    surface_albedo,                               &
-                    extraterrestrial_flux,                        &
-                    standard_gravitational_acceleration,          &
-                    cloud_area_fraction,                          &
-                    air_pressure_thickness,                       &
-                    solar_zenith_angle,                           &
-                    earth_sun_distance,                           &
-                    rate_parameters,                              &
-                    errmsg, errcode)
-      if (errcode /= 0) return
-    end if
-
-    ! Solve chemistry at the current time step
-    call micm_run(time_step, temperature, pressure, dry_air_density, rate_parameters, &
-                  constituents, log_output_unit, errmsg, errcode)
-    if (errcode /= 0) return
-  
-  end subroutine musica_ccpp_run
 
   !> \section arg_table_musica_ccpp_final Argument Table
   !! \htmlinclude musica_ccpp_final.html

--- a/schemes/musica/musica_ccpp.meta
+++ b/schemes/musica/musica_ccpp.meta
@@ -18,6 +18,12 @@
   allocatable = True
   type = ccpp_constituent_properties_t
   intent = out
+[ number_of_micm_rate_parameters ]
+  standard_name = number_of_micm_rate_parameters
+  units = count
+  type = integer
+  dimensions = ()
+  intent = out
 [ errmsg ]
   standard_name = ccpp_error_message
   units = none
@@ -68,130 +74,6 @@
   standard_name = molecular_weight_of_dry_air
   units = g mol-1
   type = real | kind = kind_phys
-  dimensions = ()
-  intent = in
-[ errmsg ]
-  standard_name = ccpp_error_message
-  units = none
-  type = character | kind = len=512
-  dimensions = ()
-  intent = out
-[ errcode ]
-  standard_name = ccpp_error_code
-  units = 1
-  type = integer
-  dimensions = ()
-  intent = out
-
-[ccpp-arg-table]
-  name  = musica_ccpp_run
-  type  = scheme
-[ time_step ]
-  standard_name = timestep_for_physics
-  units = s
-  type = real | kind = kind_phys
-  dimensions = ()
-  intent = in
-[ temperature ]
-  standard_name = air_temperature
-  units = K
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  intent = in
-[ pressure ]
-  standard_name = air_pressure
-  units = Pa
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  intent = in
-[ dry_air_density ]
-  standard_name = dry_air_density
-  units = kg m-3
-  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
-  type = real | kind = kind_phys
-  intent = in
-[ constituent_props ]
-  standard_name = ccpp_constituent_properties
-  units = None
-  type = ccpp_constituent_prop_ptr_t
-  dimensions = (number_of_ccpp_constituents)
-  intent = in
-[ constituents ]
-  standard_name = ccpp_constituents
-  units = none
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_ccpp_constituents)
-  intent = inout
-[ geopotential_height_wrt_surface_at_midpoint ]
-  standard_name = geopotential_height_wrt_surface
-  units = m
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  intent = in
-[ geopotential_height_wrt_surface_at_interface ]
-  standard_name = geopotential_height_wrt_surface_at_interface
-  units = m
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
-  intent = in
-[ surface_geopotential ]
-  standard_name = surface_geopotential
-  type = real | kind = kind_phys
-  units = m2 s-2
-  dimensions = (horizontal_loop_extent)
-  intent = in
-[ surface_temperature ]
-  standard_name = blackbody_temperature_at_surface
-  type = real | kind = kind_phys
-  units = K
-  dimensions = (horizontal_loop_extent)
-  intent = in
-[ surface_albedo ]
-  standard_name = surface_albedo_due_to_UV_and_VIS_direct
-  type = real | kind = kind_phys
-  units = fraction
-  dimensions = (horizontal_loop_extent)
-  intent = in
-[ extraterrestrial_flux ]
-  standard_name = extraterrestrial_radiation_flux
-  type = real | kind = kind_phys
-  units = photons cm-2 s-1 nm-1
-  dimensions = (photolysis_wavelength_grid_section_dimension)
-  intent = in
-[ standard_gravitational_acceleration ]
-  standard_name = standard_gravitational_acceleration
-  units = m s-2
-  type = real | kind = kind_phys
-  dimensions = ()
-  intent = in
-[ cloud_area_fraction ]
-  standard_name = cloud_area_fraction
-  units = fraction
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  intent = in
-[ air_pressure_thickness ]
-  standard_name = air_pressure_thickness
-  units = Pa
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  intent = in
-[ solar_zenith_angle ]
-  standard_name = solar_zenith_angle
-  units = rad
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent)
-  intent = in
-[ earth_sun_distance ]
-  standard_name = earth_sun_distance
-  units = AU
-  type = real | kind = kind_phys
-  dimensions = ()
-  intent = in
-[ log_output_unit ]
-  standard_name = log_output_unit
-  units = 1
-  type = integer
   dimensions = ()
   intent = in
 [ errmsg ]

--- a/schemes/musica/musica_ccpp_chemistry.F90
+++ b/schemes/musica/musica_ccpp_chemistry.F90
@@ -1,4 +1,4 @@
-! Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+! Copyright (C) 2024-2026 University Corporation for Atmospheric Research
 ! SPDX-License-Identifier: Apache-2.0
 
 !> Gas-phase chemistry solve using MICM for MUSICA chemistry
@@ -26,8 +26,11 @@ contains
     real(kind_phys), target, intent(in)    :: rate_parameters(:,:,:) ! various units (column, layer, parameter)
     real(kind_phys), target, intent(inout) :: constituents(:,:,:)  ! kg kg-1 (column, layer, constituent)
     integer,                 intent(in)    :: log_output_unit      ! file unit number for logging
-    character(len=512),      intent(out)   :: errmsg
+    character(len=*),        intent(out)   :: errmsg
     integer,                 intent(out)   :: errcode
+
+    errcode = 0
+    errmsg = ''
 
     call micm_run(time_step, temperature, pressure, dry_air_density, rate_parameters, &
                   constituents, log_output_unit, errmsg, errcode)

--- a/schemes/musica/musica_ccpp_chemistry.F90
+++ b/schemes/musica/musica_ccpp_chemistry.F90
@@ -1,0 +1,38 @@
+! Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+
+!> Gas-phase chemistry solve using MICM for MUSICA chemistry
+module musica_ccpp_chemistry
+
+  implicit none
+  private
+
+  public :: musica_ccpp_chemistry_run
+
+contains
+
+  !> \section arg_table_musica_ccpp_chemistry_run Argument Table
+  !! \htmlinclude musica_ccpp_chemistry_run.html
+  subroutine musica_ccpp_chemistry_run(time_step, temperature, pressure, dry_air_density, &
+                                       rate_parameters, constituents, log_output_unit,    &
+                                       errmsg, errcode)
+    use ccpp_kinds,       only: kind_phys
+    use musica_ccpp_micm, only: micm_run
+
+    real(kind_phys),         intent(in)    :: time_step            ! s
+    real(kind_phys), target, intent(in)    :: temperature(:,:)     ! K (column, layer)
+    real(kind_phys), target, intent(in)    :: pressure(:,:)        ! Pa (column, layer)
+    real(kind_phys), target, intent(in)    :: dry_air_density(:,:) ! kg m-3 (column, layer)
+    real(kind_phys), target, intent(in)    :: rate_parameters(:,:,:) ! various units (column, layer, parameter)
+    real(kind_phys), target, intent(inout) :: constituents(:,:,:)  ! kg kg-1 (column, layer, constituent)
+    integer,                 intent(in)    :: log_output_unit      ! file unit number for logging
+    character(len=512),      intent(out)   :: errmsg
+    integer,                 intent(out)   :: errcode
+
+    call micm_run(time_step, temperature, pressure, dry_air_density, rate_parameters, &
+                  constituents, log_output_unit, errmsg, errcode)
+    if (errcode /= 0) return
+
+  end subroutine musica_ccpp_chemistry_run
+
+end module musica_ccpp_chemistry

--- a/schemes/musica/musica_ccpp_chemistry.meta
+++ b/schemes/musica/musica_ccpp_chemistry.meta
@@ -52,7 +52,7 @@
 [ errmsg ]
   standard_name = ccpp_error_message
   units = none
-  type = character | kind = len=512
+  type = character | kind = len=*
   dimensions = ()
   intent = out
 [ errcode ]

--- a/schemes/musica/musica_ccpp_chemistry.meta
+++ b/schemes/musica/musica_ccpp_chemistry.meta
@@ -1,0 +1,63 @@
+[ccpp-table-properties]
+  name = musica_ccpp_chemistry
+  type = scheme
+  dependencies = micm/musica_ccpp_micm_util.F90,micm/musica_ccpp_micm.F90
+  dependencies = util/musica_ccpp_grid.F90,util/musica_ccpp_species.F90,util/musica_ccpp_util.F90
+
+[ccpp-arg-table]
+  name  = musica_ccpp_chemistry_run
+  type  = scheme
+[ time_step ]
+  standard_name = timestep_for_physics
+  units = s
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ temperature ]
+  standard_name = air_temperature
+  units = K
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  intent = in
+[ pressure ]
+  standard_name = air_pressure
+  units = Pa
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  intent = in
+[ dry_air_density ]
+  standard_name = dry_air_density
+  units = kg m-3
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  type = real | kind = kind_phys
+  intent = in
+[ rate_parameters ]
+  standard_name = micm_rate_parameters
+  units = none
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_micm_rate_parameters)
+  intent = in
+[ constituents ]
+  standard_name = ccpp_constituents
+  units = none
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_ccpp_constituents)
+  intent = inout
+[ log_output_unit ]
+  standard_name = log_output_unit
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errcode ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/musica/musica_ccpp_photolysis.F90
+++ b/schemes/musica/musica_ccpp_photolysis.F90
@@ -1,4 +1,4 @@
-! Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+! Copyright (C) 2024-2026 University Corporation for Atmospheric Research
 ! SPDX-License-Identifier: Apache-2.0
 
 !> Photolysis rate constant calculation using TUV-x for MUSICA chemistry
@@ -47,7 +47,7 @@ contains
     real(kind_phys),         intent(in)  :: solar_zenith_angle(:)                             ! radians (column)
     real(kind_phys),         intent(in)  :: earth_sun_distance                                ! AU
     real(kind_phys),         intent(out) :: rate_parameters(:,:,:)                            ! various units (column, layer, parameter)
-    character(len=512),      intent(out) :: errmsg
+    character(len=*),        intent(out) :: errmsg
     integer,                 intent(out) :: errcode
 
     ! local variables

--- a/schemes/musica/musica_ccpp_photolysis.F90
+++ b/schemes/musica/musica_ccpp_photolysis.F90
@@ -1,0 +1,92 @@
+! Copyright (C) 2024-2025 University Corporation for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+
+!> Photolysis rate constant calculation using TUV-x for MUSICA chemistry
+module musica_ccpp_photolysis
+
+  implicit none
+  private
+
+  public :: musica_ccpp_photolysis_run
+
+contains
+
+  !> \section arg_table_musica_ccpp_photolysis_run Argument Table
+  !! \htmlinclude musica_ccpp_photolysis_run.html
+  !!
+  !! The standard name for the variable 'surface_temperature' is
+  !! 'blackbody_temperature_at_surface' as this is the standard name
+  !! used for 'cam_in%ts,' which represents the same quantity.
+  subroutine musica_ccpp_photolysis_run(temperature, dry_air_density, constituents,          &
+                                        geopotential_height_wrt_surface_at_midpoint,         &
+                                        geopotential_height_wrt_surface_at_interface,        &
+                                        surface_geopotential, surface_temperature,           &
+                                        surface_albedo, extraterrestrial_flux,               &
+                                        standard_gravitational_acceleration,                 &
+                                        cloud_area_fraction, air_pressure_thickness,         &
+                                        solar_zenith_angle, earth_sun_distance,              &
+                                        rate_parameters, errmsg, errcode)
+    use ccpp_kinds,          only: kind_phys
+    use musica_ccpp_tuvx,    only: tuvx_run
+    use musica_ccpp_util,    only: do_tuvx
+    use musica_ccpp_species, only: number_of_tuvx_species, tuvx_indices_constituent_props, &
+                                   extract_subset_constituents
+
+    real(kind_phys), target, intent(in)  :: temperature(:,:)                                  ! K (column, layer)
+    real(kind_phys), target, intent(in)  :: dry_air_density(:,:)                              ! kg m-3 (column, layer)
+    real(kind_phys), target, intent(in)  :: constituents(:,:,:)                               ! kg kg-1 (column, layer, constituent)
+    real(kind_phys),         intent(in)  :: geopotential_height_wrt_surface_at_midpoint(:,:)  ! m (column, layer)
+    real(kind_phys),         intent(in)  :: geopotential_height_wrt_surface_at_interface(:,:) ! m (column, interface)
+    real(kind_phys),         intent(in)  :: surface_geopotential(:)                           ! m2 s-2 (column)
+    real(kind_phys),         intent(in)  :: surface_temperature(:)                            ! K (column)
+    real(kind_phys),         intent(in)  :: surface_albedo(:)                                 ! fraction (column)
+    real(kind_phys),         intent(in)  :: extraterrestrial_flux(:)                          ! photons cm-2 s-1 nm-1 (wavelength interface)
+    real(kind_phys),         intent(in)  :: standard_gravitational_acceleration               ! m s-2
+    real(kind_phys),         intent(in)  :: cloud_area_fraction(:,:)                          ! fraction (column, layer)
+    real(kind_phys),         intent(in)  :: air_pressure_thickness(:,:)                       ! Pa (column, layer)
+    real(kind_phys),         intent(in)  :: solar_zenith_angle(:)                             ! radians (column)
+    real(kind_phys),         intent(in)  :: earth_sun_distance                                ! AU
+    real(kind_phys),         intent(out) :: rate_parameters(:,:,:)                            ! various units (column, layer, parameter)
+    character(len=512),      intent(out) :: errmsg
+    integer,                 intent(out) :: errcode
+
+    ! local variables
+    real(kind_phys), dimension(size(constituents, dim=1), &
+                               size(constituents, dim=2), &
+                               number_of_tuvx_species) :: constituents_tuvx_species ! kg kg-1
+
+    errmsg = ''
+    errcode = 0
+
+    ! Zero all rate parameters: TUV-x only writes the mapped photolysis slots,
+    ! so unmapped slots (USER./EMIS./LOSS./SURF. reactions, and every slot when
+    ! TUV-x is disabled) would otherwise be uninitialized memory. Zero means the
+    ! corresponding reaction is off. Schemes ordered between this scheme and
+    ! musica_ccpp_chemistry may fill non-photolysis slots.
+    rate_parameters(:,:,:) = 0.0_kind_phys
+
+    if (.not. do_tuvx) return
+
+    call extract_subset_constituents(tuvx_indices_constituent_props, constituents, &
+                                     constituents_tuvx_species, errmsg, errcode)
+    if (errcode /= 0) return
+
+    call tuvx_run(temperature, dry_air_density,                 &
+                  constituents_tuvx_species,                    &
+                  geopotential_height_wrt_surface_at_midpoint,  &
+                  geopotential_height_wrt_surface_at_interface, &
+                  surface_geopotential, surface_temperature,    &
+                  surface_albedo,                               &
+                  extraterrestrial_flux,                        &
+                  standard_gravitational_acceleration,          &
+                  cloud_area_fraction,                          &
+                  air_pressure_thickness,                       &
+                  solar_zenith_angle,                           &
+                  earth_sun_distance,                           &
+                  rate_parameters,                              &
+                  errmsg, errcode)
+    if (errcode /= 0) return
+
+  end subroutine musica_ccpp_photolysis_run
+
+end module musica_ccpp_photolysis

--- a/schemes/musica/musica_ccpp_photolysis.F90
+++ b/schemes/musica/musica_ccpp_photolysis.F90
@@ -58,10 +58,12 @@ contains
     errmsg = ''
     errcode = 0
 
-    ! Zero all rate parameters: TUV-x only writes the mapped photolysis slots,
-    ! so unmapped slots (USER./EMIS./LOSS./SURF. reactions, and every slot when
-    ! TUV-x is disabled) would otherwise be uninitialized memory. Zero means the
-    ! corresponding reaction is off. Schemes ordered between this scheme and
+    ! Zero all rate parameters at initialization.
+    ! TUV-x only writes the mapped photolysis slots, so unmapped slots
+    ! (USER./EMIS./LOSS./SURF. reactions)
+    ! would otherwise be uninitialized memory.
+    !
+    ! Schemes ordered between this scheme and
     ! musica_ccpp_chemistry may fill non-photolysis slots.
     rate_parameters(:,:,:) = 0.0_kind_phys
 

--- a/schemes/musica/musica_ccpp_photolysis.meta
+++ b/schemes/musica/musica_ccpp_photolysis.meta
@@ -1,0 +1,115 @@
+[ccpp-table-properties]
+  name = musica_ccpp_photolysis
+  type = scheme
+  dependencies = micm/musica_ccpp_micm_util.F90,micm/musica_ccpp_micm.F90
+  dependencies = tuvx/musica_ccpp_tuvx_aerosol_optics.F90,tuvx/musica_ccpp_tuvx_cloud_optics.F90,tuvx/musica_ccpp_tuvx_extraterrestrial_flux.F90
+  dependencies = tuvx/musica_ccpp_tuvx_gas_species.F90,tuvx/musica_ccpp_tuvx_height_grid.F90,tuvx/musica_ccpp_tuvx_load_species.F90
+  dependencies = tuvx/musica_ccpp_tuvx_surface_albedo.F90,tuvx/musica_ccpp_tuvx_temperature.F90,tuvx/musica_ccpp_tuvx_wavelength_grid.F90
+  dependencies = tuvx/musica_ccpp_tuvx.F90
+  dependencies = util/musica_ccpp_grid.F90,util/musica_ccpp_species.F90,util/musica_ccpp_util.F90
+
+[ccpp-arg-table]
+  name  = musica_ccpp_photolysis_run
+  type  = scheme
+[ temperature ]
+  standard_name = air_temperature
+  units = K
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  intent = in
+[ dry_air_density ]
+  standard_name = dry_air_density
+  units = kg m-3
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  type = real | kind = kind_phys
+  intent = in
+[ constituents ]
+  standard_name = ccpp_constituents
+  units = none
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_ccpp_constituents)
+  intent = in
+[ geopotential_height_wrt_surface_at_midpoint ]
+  standard_name = geopotential_height_wrt_surface
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  intent = in
+[ geopotential_height_wrt_surface_at_interface ]
+  standard_name = geopotential_height_wrt_surface_at_interface
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
+  intent = in
+[ surface_geopotential ]
+  standard_name = surface_geopotential
+  type = real | kind = kind_phys
+  units = m2 s-2
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ surface_temperature ]
+  standard_name = blackbody_temperature_at_surface
+  type = real | kind = kind_phys
+  units = K
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ surface_albedo ]
+  standard_name = surface_albedo_due_to_UV_and_VIS_direct
+  type = real | kind = kind_phys
+  units = fraction
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ extraterrestrial_flux ]
+  standard_name = extraterrestrial_radiation_flux
+  type = real | kind = kind_phys
+  units = photons cm-2 s-1 nm-1
+  dimensions = (photolysis_wavelength_grid_section_dimension)
+  intent = in
+[ standard_gravitational_acceleration ]
+  standard_name = standard_gravitational_acceleration
+  units = m s-2
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ cloud_area_fraction ]
+  standard_name = cloud_area_fraction
+  units = fraction
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  intent = in
+[ air_pressure_thickness ]
+  standard_name = air_pressure_thickness
+  units = Pa
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  intent = in
+[ solar_zenith_angle ]
+  standard_name = solar_zenith_angle
+  units = rad
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ earth_sun_distance ]
+  standard_name = earth_sun_distance
+  units = AU
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ rate_parameters ]
+  standard_name = micm_rate_parameters
+  units = none
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_micm_rate_parameters)
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  units = none
+  type = character | kind = len=512
+  dimensions = ()
+  intent = out
+[ errcode ]
+  standard_name = ccpp_error_code
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/musica/musica_ccpp_photolysis.meta
+++ b/schemes/musica/musica_ccpp_photolysis.meta
@@ -104,7 +104,7 @@
 [ errmsg ]
   standard_name = ccpp_error_message
   units = none
-  type = character | kind = len=512
+  type = character | kind = len=*
   dimensions = ()
   intent = out
 [ errcode ]

--- a/schemes/musica/tuvx/musica_ccpp_tuvx_gas_species.F90
+++ b/schemes/musica/tuvx/musica_ccpp_tuvx_gas_species.F90
@@ -94,7 +94,7 @@ contains
   !> Sets the species constituents in the vertical layer
   subroutine set_gas_species_values(profile, dry_air_density, constituents, &
                                 height_deltas, index_species, errmsg, errcode)
-    use musica_ccpp_util,              only: has_error_occurred
+    use musica_ccpp_util,              only: has_error_occurred, AVOGADRO
     use musica_ccpp_species,           only: tuvx_species_set
     use musica_ccpp_tuvx_load_species, only: O3_LABEL
     use musica_tuvx_profile,           only: profile_t
@@ -111,18 +111,22 @@ contains
     ! local variables
     type(error_t)   :: error
     integer         :: num_vertical_levels
-    real(kind_phys) :: constituent_mol_per_cm_3(size(constituents)) ! mol cm-3
+    real(kind_phys) :: constituent_molec_per_cm_3(size(constituents)) ! molecule cm-3
     real(kind_phys) :: interfaces(size(constituents) + 2)
     real(kind_phys) :: densities(size(constituents) + 1)
     real(kind_phys) :: molar_mass
 
     molar_mass = tuvx_species_set(index_species)%molar_mass
-    constituent_mol_per_cm_3(:) = constituents(:) * dry_air_density(:) / molar_mass / m_3_to_cm_3
+    ! TUV-x gas profiles are number densities (molecule cm-3, matching its
+    ! per-molecule cross sections), so the mole count must be scaled by
+    ! Avogadro's number
+    constituent_molec_per_cm_3(:) = constituents(:) * dry_air_density(:) / molar_mass &
+                                    * AVOGADRO / m_3_to_cm_3
 
     num_vertical_levels = size(constituents)
-    interfaces(1) = constituent_mol_per_cm_3(num_vertical_levels)
-    interfaces(2:num_vertical_levels+1) = constituent_mol_per_cm_3(num_vertical_levels:1:-1)
-    interfaces(num_vertical_levels+2) = constituent_mol_per_cm_3(1)
+    interfaces(1) = constituent_molec_per_cm_3(num_vertical_levels)
+    interfaces(2:num_vertical_levels+1) = constituent_molec_per_cm_3(num_vertical_levels:1:-1)
+    interfaces(num_vertical_levels+2) = constituent_molec_per_cm_3(1)
 
     if (tuvx_species_set(index_species)%name == O3_LABEL) then
       densities(:) = height_deltas(:) * km_to_cm * 0.5_kind_phys &

--- a/schemes/musica/util/musica_ccpp_util.F90
+++ b/schemes/musica/util/musica_ccpp_util.F90
@@ -11,6 +11,7 @@ module musica_ccpp_util
 
   real(kind_phys), parameter, public :: PI = 3.14159265358979323846_kind_phys
   real(kind_phys), parameter, public :: DEGREE_TO_RADIAN = PI / 180.0_kind_phys
+  real(kind_phys), parameter, public :: AVOGADRO = 6.02214179e23_kind_phys ! molecules mol-1
   real(kind_phys), public, protected :: MOLAR_MASS_DRY_AIR = -HUGE(1.0_kind_phys) ! kg mol-1
 
   !> Conversion factor for wavelength interfaces from meters (CAM-SIMA) to nanometers (TUV-x)

--- a/schemes/musica/util/musica_ccpp_util.F90
+++ b/schemes/musica/util/musica_ccpp_util.F90
@@ -7,12 +7,16 @@ module musica_ccpp_util
   implicit none
 
   private
-  public :: has_error_occurred, set_constants
+  public :: has_error_occurred, set_constants, set_do_tuvx
 
   real(kind_phys), parameter, public :: PI = 3.14159265358979323846_kind_phys
   real(kind_phys), parameter, public :: DEGREE_TO_RADIAN = PI / 180.0_kind_phys
   real(kind_phys), parameter, public :: AVOGADRO = 6.02214179e23_kind_phys ! molecules mol-1
   real(kind_phys), public, protected :: MOLAR_MASS_DRY_AIR = -HUGE(1.0_kind_phys) ! kg mol-1
+
+  !> Whether TUV-x photolysis is enabled; set during the register phase from
+  !! the TUV-x configuration file namelist option
+  logical, public, protected :: do_tuvx = .false.
 
   !> Conversion factor for wavelength interfaces from meters (CAM-SIMA) to nanometers (TUV-x)
   real(kind_phys), parameter, public :: m_to_nm = 1.0e9_kind_phys
@@ -27,6 +31,14 @@ contains
 
     MOLAR_MASS_DRY_AIR = molar_mass_dry_air_in
   end subroutine set_constants
+
+  !> @brief Set whether TUV-x photolysis is enabled
+  subroutine set_do_tuvx(do_tuvx_in)
+
+    logical, intent(in) :: do_tuvx_in
+
+    do_tuvx = do_tuvx_in
+  end subroutine set_do_tuvx
 
   !> @brief Evaluate a MUSICA error for failure and convert to CCPP error data
   !> @param[in] error The error code to evaluate and convert.

--- a/suites/suite_musica.xml
+++ b/suites/suite_musica.xml
@@ -3,7 +3,14 @@
 <suite name="musica" version="1.0">
   <group name="physics_after_coupler">
     <scheme>calc_dry_air_ideal_gas_density</scheme>
+    <!-- musica_ccpp handles the register/init/final phases shared by the
+         photolysis and chemistry run schemes. Schemes that provide additional
+         rate parameters (e.g. heterogeneous or user-defined reaction rates)
+         may be placed between musica_ccpp_photolysis and
+         musica_ccpp_chemistry to write into micm_rate_parameters. -->
     <scheme>musica_ccpp</scheme>
+    <scheme>musica_ccpp_photolysis</scheme>
+    <scheme>musica_ccpp_chemistry</scheme>
 
     <!-- State diagnostics -->
     <scheme>sima_state_diagnostics</scheme>

--- a/test/musica/CMakeLists.txt
+++ b/test/musica/CMakeLists.txt
@@ -37,6 +37,10 @@ add_custom_target(
   copy_metadata_test_files ALL ${CMAKE_COMMAND} -E copy
   ${CMAKE_CURRENT_SOURCE_DIR}/../../schemes/musica/musica_ccpp.meta
   ${CMAKE_CURRENT_SOURCE_DIR}/../../schemes/musica/musica_ccpp.F90
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../schemes/musica/musica_ccpp_photolysis.meta
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../schemes/musica/musica_ccpp_photolysis.F90
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../schemes/musica/musica_ccpp_chemistry.meta
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../schemes/musica/musica_ccpp_chemistry.F90
   ${CMAKE_BINARY_DIR}/metadata_test
 )
 

--- a/test/musica/micm/test_micm_util.F90
+++ b/test/musica/micm/test_micm_util.F90
@@ -64,11 +64,21 @@ contains
 
     ccpp_constituents(:,:,:) = constituents(:,:,:)
     
-    ! Set the expected values for the constituents in mol m-3
-    micm_constituents(:,:,1) = ccpp_constituents(:,:,1) * dry_air_mass_density(:,:) / ( MOLAR_MASS_DRY_AIR * micm_molar_mass_array(1) )
-    micm_constituents(:,:,2) = ccpp_constituents(:,:,2) * dry_air_mass_density(:,:) / ( MOLAR_MASS_DRY_AIR * micm_molar_mass_array(2) )
-    micm_constituents(:,:,3) = ccpp_constituents(:,:,3) * dry_air_mass_density(:,:) / ( MOLAR_MASS_DRY_AIR * micm_molar_mass_array(3) )
-    micm_constituents(:,:,4) = ccpp_constituents(:,:,4) * dry_air_mass_density(:,:) / ( MOLAR_MASS_DRY_AIR * micm_molar_mass_array(4) )
+    ! Set the expected values for the constituents in mol m-3:
+    ! MMR (kg kg-1) * dry air mass density (kg m-3) / species molar mass (kg mol-1)
+    micm_constituents(:,:,1) = ccpp_constituents(:,:,1) * dry_air_mass_density(:,:) / micm_molar_mass_array(1)
+    micm_constituents(:,:,2) = ccpp_constituents(:,:,2) * dry_air_mass_density(:,:) / micm_molar_mass_array(2)
+    micm_constituents(:,:,3) = ccpp_constituents(:,:,3) * dry_air_mass_density(:,:) / micm_molar_mass_array(3)
+    micm_constituents(:,:,4) = ccpp_constituents(:,:,4) * dry_air_mass_density(:,:) / micm_molar_mass_array(4)
+
+    ! Hand-computed known-answer checks pin the conversion formula itself: the
+    ! stray division by the dry air molar mass (a ~34.5x error in every
+    ! second-order reaction rate) is invisible to the round-trip and
+    ! conservation checks below because the extraction path inverts it exactly.
+    ! cell (1,1) species 1: 0.1 kg/kg * 3.5 kg/m3 / 200 kg/mol = 1.75e-3 mol/m3
+    ! cell (2,2) species 4: 0.34 kg/kg * 6.5 kg/m3 / 250 kg/mol = 8.84e-3 mol/m3
+    ASSERT_NEAR(micm_constituents(1,1,1), 1.75e-3_kind_phys, 1.0e-12_kind_phys)
+    ASSERT_NEAR(micm_constituents(2,2,4), 8.84e-3_kind_phys, 1.0e-12_kind_phys)
 
     call update_micm_state(state, 0, temperature, pressure, dry_air_mass_density, constituents, rate_parameters)
 
@@ -88,7 +98,7 @@ contains
     end do
 
     constituents(:,:,:) = -HUGE(1.0_kind_phys)
-    call extract_mixing_ratios_from_state(state, 0, constituents)
+    call extract_mixing_ratios_from_state(state, 0, dry_air_mass_density, constituents)
 
     do i_column = 1, NUM_COLUMNS
       do i_layer = 1, NUM_LAYERS

--- a/test/musica/micm/test_micm_util.F90
+++ b/test/musica/micm/test_micm_util.F90
@@ -71,10 +71,6 @@ contains
     micm_constituents(:,:,3) = ccpp_constituents(:,:,3) * dry_air_mass_density(:,:) / micm_molar_mass_array(3)
     micm_constituents(:,:,4) = ccpp_constituents(:,:,4) * dry_air_mass_density(:,:) / micm_molar_mass_array(4)
 
-    ! Hand-computed known-answer checks pin the conversion formula itself: the
-    ! stray division by the dry air molar mass (a ~34.5x error in every
-    ! second-order reaction rate) is invisible to the round-trip and
-    ! conservation checks below because the extraction path inverts it exactly.
     ! cell (1,1) species 1: 0.1 kg/kg * 3.5 kg/m3 / 200 kg/mol = 1.75e-3 mol/m3
     ! cell (2,2) species 4: 0.34 kg/kg * 6.5 kg/m3 / 250 kg/mol = 8.84e-3 mol/m3
     ASSERT_NEAR(micm_constituents(1,1,1), 1.75e-3_kind_phys, 1.0e-12_kind_phys)

--- a/test/musica/test_musica_api.F90
+++ b/test/musica/test_musica_api.F90
@@ -3,6 +3,8 @@
 program run_test_musica_ccpp
 
   use musica_ccpp
+  use musica_ccpp_chemistry,  only: musica_ccpp_chemistry_run
+  use musica_ccpp_photolysis, only: musica_ccpp_photolysis_run
   use musica_test_data, only: get_wavelength_edges, get_extrarterrestrial_fluxes
   use ccpp_kinds,       only: kind_phys
 
@@ -115,6 +117,8 @@ contains
     type(ccpp_constituent_prop_ptr_t),   allocatable                 :: constituent_props_ptr(:)
     type(ccpp_constituent_properties_t), allocatable, target         :: constituent_props(:)
     type(ccpp_constituent_properties_t), pointer                     :: const_prop
+    integer                                                          :: number_of_micm_rate_parameters
+    real(kind_phys), allocatable                                     :: rate_parameters(:,:,:) ! various units
     real(kind_phys)                                                  :: molar_mass, base_conc, default_mixing_ratio
     character(len=512)                                               :: species_name, units
     character(len=:), allocatable                                    :: micm_species_name
@@ -155,7 +159,8 @@ contains
     ! solver selection
     micm_solver_type = 'Rosenbrock'
 
-    call musica_ccpp_register(constituent_props, errmsg, errcode)
+    call musica_ccpp_register(constituent_props, number_of_micm_rate_parameters, &
+                              errmsg, errcode)
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3
@@ -267,13 +272,24 @@ contains
     write(*,*) "[MUSICA INFO] Initial Concentrations"
     write(*,fmt="(4(3x,e13.6))") constituents
 
-    call musica_ccpp_run( time_step, temperature, pressure, dry_air_density, constituent_props_ptr, &
-                          constituents, geopotential_height_wrt_surface_at_midpoint,                &
-                          geopotential_height_wrt_surface_at_interface, surface_geopotential,       &
-                          surface_temperature, surface_albedo, extraterrestrial_radiation_flux,     &
-                          standard_gravitational_acceleration, cloud_area_fraction,                 &
-                          air_pressure_thickness, solar_zenith_angle, earth_sun_distance, STDOUT,   &
-                          errmsg, errcode )
+    ! The framework allocates micm_rate_parameters from the register-phase
+    ! count; the test mirrors that here
+    allocate(rate_parameters(NUM_COLUMNS, NUM_LAYERS, number_of_micm_rate_parameters))
+    call musica_ccpp_photolysis_run( temperature, dry_air_density, constituents,       &
+                          geopotential_height_wrt_surface_at_midpoint,                 &
+                          geopotential_height_wrt_surface_at_interface,                &
+                          surface_geopotential, surface_temperature, surface_albedo,   &
+                          extraterrestrial_radiation_flux,                             &
+                          standard_gravitational_acceleration, cloud_area_fraction,    &
+                          air_pressure_thickness, solar_zenith_angle,                  &
+                          earth_sun_distance, rate_parameters, errmsg, errcode )
+    if (errcode /= 0) then
+      write(*,*) trim(errmsg)
+      stop 3
+    endif
+    call musica_ccpp_chemistry_run( time_step, temperature, pressure, dry_air_density, &
+                          rate_parameters, constituents, STDOUT, errmsg, errcode )
+    deallocate(rate_parameters)
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3
@@ -374,6 +390,8 @@ contains
     type(ccpp_constituent_prop_ptr_t),   allocatable               :: constituent_props_ptr(:)
     type(ccpp_constituent_properties_t), allocatable, target       :: constituent_props(:)
     type(ccpp_constituent_properties_t), pointer                   :: const_prop
+    integer                                                        :: number_of_micm_rate_parameters
+    real(kind_phys), allocatable                                   :: rate_parameters(:,:,:) ! various units
     real(kind_phys)                                                :: molar_mass, base_conc
     character(len=512)                                             :: species_name, units
     character(len=:), allocatable                                  :: micm_species_name
@@ -412,7 +430,8 @@ contains
     ! set explicitly: see note in test_chapman
     micm_solver_type = 'Rosenbrock'
 
-    call musica_ccpp_register(constituent_props, errmsg, errcode)
+    call musica_ccpp_register(constituent_props, number_of_micm_rate_parameters, &
+                              errmsg, errcode)
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3
@@ -515,13 +534,24 @@ contains
     write(*,*) "[MUSICA INFO] Initial Concentrations"
     write(*,fmt="(4(3x,e13.6))") constituents
 
-    call musica_ccpp_run( time_step, temperature, pressure, dry_air_density, constituent_props_ptr, &
-                          constituents, geopotential_height_wrt_surface_at_midpoint,                &
-                          geopotential_height_wrt_surface_at_interface, surface_geopotential,       &
-                          surface_temperature, surface_albedo, extraterrestrial_radiation_flux,     &
-                          standard_gravitational_acceleration, cloud_area_fraction,                 &
-                          air_pressure_thickness, solar_zenith_angle, earth_sun_distance, STDOUT,   &
-                          errmsg, errcode )
+    ! The framework allocates micm_rate_parameters from the register-phase
+    ! count; the test mirrors that here
+    allocate(rate_parameters(NUM_COLUMNS, NUM_LAYERS, number_of_micm_rate_parameters))
+    call musica_ccpp_photolysis_run( temperature, dry_air_density, constituents,       &
+                          geopotential_height_wrt_surface_at_midpoint,                 &
+                          geopotential_height_wrt_surface_at_interface,                &
+                          surface_geopotential, surface_temperature, surface_albedo,   &
+                          extraterrestrial_radiation_flux,                             &
+                          standard_gravitational_acceleration, cloud_area_fraction,    &
+                          air_pressure_thickness, solar_zenith_angle,                  &
+                          earth_sun_distance, rate_parameters, errmsg, errcode )
+    if (errcode /= 0) then
+      write(*,*) trim(errmsg)
+      stop 3
+    endif
+    call musica_ccpp_chemistry_run( time_step, temperature, pressure, dry_air_density, &
+                          rate_parameters, constituents, STDOUT, errmsg, errcode )
+    deallocate(rate_parameters)
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3
@@ -637,6 +667,9 @@ contains
     real(kind_phys)                                                :: k1, k2, k3, k4
     real(kind_phys)                                                :: dummy_array_1D(1), dummy_array_2D(1,1)
 
+    integer                       :: number_of_micm_rate_parameters
+    real(kind_phys), allocatable  :: rate_parameters(:,:,:) ! various units
+
     NUM_GRID_CELLS = number_of_columns * number_of_layers
     dummy_array_1D = -HUGE(0.0_kind_phys)
     dummy_array_2D = -HUGE(0.0_kind_phys)
@@ -646,7 +679,8 @@ contains
     filename_of_tuvx_micm_mapping_configuration = 'none'
 
     ! MUSICA registration
-    call musica_ccpp_register(constituent_props, errmsg, errcode)
+    call musica_ccpp_register(constituent_props, number_of_micm_rate_parameters, &
+                              errmsg, errcode)
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3
@@ -713,10 +747,19 @@ contains
     end do
 
     ! MUSICA run for one time step
-    call musica_ccpp_run( time_step, temperature, pressure, dry_air_mass_density, constituent_props_ptr, &
-                          constituents, dummy_array_2D, dummy_array_2D, dummy_array_1D, dummy_array_1D, &
+    allocate(rate_parameters(number_of_columns, number_of_layers, number_of_micm_rate_parameters))
+    call musica_ccpp_photolysis_run( temperature, dry_air_mass_density, constituents, &
+                          dummy_array_2D, dummy_array_2D, dummy_array_1D, dummy_array_1D, &
                           dummy_array_1D, dummy_array_1D, -HUGE(0.0_kind_phys), dummy_array_2D, &
-                          dummy_array_2D, dummy_array_1D, -HUGE(0.0_kind_phys), STDOUT, errmsg, errcode )
+                          dummy_array_2D, dummy_array_1D, -HUGE(0.0_kind_phys), rate_parameters, &
+                          errmsg, errcode )
+    if (errcode /= 0) then
+      write(*,*) trim(errmsg)
+      stop 3
+    endif
+    call musica_ccpp_chemistry_run( time_step, temperature, pressure, dry_air_mass_density, &
+                          rate_parameters, constituents, STDOUT, errmsg, errcode )
+    deallocate(rate_parameters)
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3

--- a/test/musica/test_musica_api.F90
+++ b/test/musica/test_musica_api.F90
@@ -30,14 +30,10 @@ program run_test_musica_ccpp
     real(kind_phys) :: E_ = 0.0
   end type ArrheniusReaction
 
-  write(*,*) "[MUSICA Test] Running the Chapman test"
-  call test_chapman()
-  write(*,*) "[MUSICA Test] Ends the Chapman test"
-
-  write(*,*) "[MUSICA Test] Running the Terminator test"
-  call test_terminator()
-  write(*,*) "[MUSICA Test] Ends the Terminator test"
-
+  ! The analytical tests disable TUV-x (filename_of_tuvx_configuration =
+  ! 'none') and must run FIRST: the TUV-x species indices are module state
+  ! that is never reset, so running a TUV-x-enabled test before them would
+  ! mask a missing do_tuvx guard in the register phase
   write(*,*) "[MUSICA Test] Running the Analytical test with Rosenbrock solver"
   call test_rosenbrock()
   write(*,*) "[MUSICA Test] Ends the Analytical test with Rosenbrock solver"
@@ -45,6 +41,14 @@ program run_test_musica_ccpp
   write(*,*) "[MUSICA Test] Running the Analytical test with Backward Euler solver"
   call test_backward_euler()
   write(*,*) "[MUSICA Test] Ends the Analytical test with Backward Euler solver"
+
+  write(*,*) "[MUSICA Test] Running the Chapman test"
+  call test_chapman()
+  write(*,*) "[MUSICA Test] Ends the Chapman test"
+
+  write(*,*) "[MUSICA Test] Running the Terminator test"
+  call test_terminator()
+  write(*,*) "[MUSICA Test] Ends the Terminator test"
 
 contains
 
@@ -70,7 +74,8 @@ contains
     use ccpp_const_utils,              only: ccpp_const_get_idx
     use musica_ccpp_namelist,          only: filename_of_micm_configuration, &
                                              filename_of_tuvx_configuration, &
-                                             filename_of_tuvx_micm_mapping_configuration
+                                             filename_of_tuvx_micm_mapping_configuration, &
+                                             micm_solver_type
     use musica_ccpp_tuvx_load_species, only: index_dry_air, index_O2, index_O3
 
     implicit none
@@ -145,6 +150,10 @@ contains
     filename_of_micm_configuration = 'musica_configurations/chapman/micm/config.json'
     filename_of_tuvx_configuration = 'musica_configurations/chapman/tuvx/config.json'
     filename_of_tuvx_micm_mapping_configuration = 'musica_configurations/chapman/tuvx_micm_mapping.json'
+    ! set explicitly: the namelist variables are module state shared across the
+    ! sub-tests, so relying on the default would inherit the previous sub-test's
+    ! solver selection
+    micm_solver_type = 'Rosenbrock'
 
     call musica_ccpp_register(constituent_props, errmsg, errcode)
     if (errcode /= 0) then
@@ -324,7 +333,8 @@ contains
     use ccpp_const_utils,              only: ccpp_const_get_idx
     use musica_ccpp_namelist,          only: filename_of_micm_configuration, &
                                              filename_of_tuvx_configuration, &
-                                             filename_of_tuvx_micm_mapping_configuration
+                                             filename_of_tuvx_micm_mapping_configuration, &
+                                             micm_solver_type
     use musica_ccpp_tuvx_load_species, only: index_dry_air, index_O2, index_O3
 
     implicit none
@@ -399,6 +409,8 @@ contains
     filename_of_micm_configuration = 'musica_configurations/terminator/micm/config.json'
     filename_of_tuvx_configuration = 'musica_configurations/terminator/tuvx/config.json'
     filename_of_tuvx_micm_mapping_configuration = 'musica_configurations/terminator/tuvx_micm_mapping.json'
+    ! set explicitly: see note in test_chapman
+    micm_solver_type = 'Rosenbrock'
 
     call musica_ccpp_register(constituent_props, errmsg, errcode)
     if (errcode /= 0) then

--- a/test/musica/test_musica_api.F90
+++ b/test/musica/test_musica_api.F90
@@ -32,9 +32,10 @@ program run_test_musica_ccpp
     real(kind_phys) :: E_ = 0.0
   end type ArrheniusReaction
 
-  ! The analytical tests disable TUV-x (filename_of_tuvx_configuration =
-  ! 'none') and must run FIRST: the TUV-x species indices are module state
-  ! that is never reset, so running a TUV-x-enabled test before them would
+  ! The analytical tests disable TUV-x and must run FIRST:
+  ! (filename_of_tuvx_configuration = 'none')
+  ! the TUV-x species indices are module state that is never reset,
+  ! so running a TUV-x-enabled test before them would
   ! mask a missing do_tuvx guard in the register phase
   write(*,*) "[MUSICA Test] Running the Analytical test with Rosenbrock solver"
   call test_rosenbrock()

--- a/test/musica/test_musica_species.F90
+++ b/test/musica/test_musica_species.F90
@@ -103,11 +103,14 @@ contains
     integer                          							           :: errcode
     integer                                                  :: i
 
+    integer                                                  :: number_of_micm_rate_parameters
+
     filename_of_micm_configuration = 'musica_configurations/chapman/micm/config.json'
     filename_of_tuvx_configuration = 'musica_configurations/chapman/tuvx/config.json'
     filename_of_tuvx_micm_mapping_configuration = 'musica_configurations/chapman/tuvx_micm_mapping.json'
 
-    call musica_ccpp_register( constituent_props, errmsg, errcode )
+    call musica_ccpp_register( constituent_props, number_of_micm_rate_parameters, &
+                               errmsg, errcode )
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3

--- a/test/musica/tuvx/test_tuvx_gas_species.F90
+++ b/test/musica/tuvx/test_tuvx_gas_species.F90
@@ -189,10 +189,8 @@ contains
       do i = 1, size(dry_air_interfaces)
         ASSERT(dry_air_interfaces(i) == expected_dry_air_interfaces(i_col, i))
       end do
-      ! Hand-computed known-answer checks pin the conversion to number density
-      ! (molecule cm-3): omitting Avogadro's number (a ~6.0e23x underestimate
-      ! of all gas optical depths) is invisible to the mirrored-formula checks
-      ! above. Column 1 dry air, MW 0.0289644 kg mol-1:
+
+      ! Column 1 dry air, MW 0.0289644 kg mol-1:
       !   layer 2: 0.5 kg/kg * 5.5 kg/m3 -> 5.71767e19 molecule cm-3 (interface 1)
       !   layer 1: 0.4 kg/kg * 3.5 kg/m3 -> 2.91081e19 molecule cm-3 (interface 3)
       if (i_col == 1) then

--- a/test/musica/tuvx/test_tuvx_gas_species.F90
+++ b/test/musica/tuvx/test_tuvx_gas_species.F90
@@ -106,6 +106,8 @@ contains
     real(kind_phys)                     :: O3_exo_layer_density
     real(kind_phys)                     :: expected_O3_exo_layer_density = SCALE_HEIGHT_O3
 
+    integer                             :: number_of_micm_rate_parameters
+
     filename_of_micm_configuration = 'musica_configurations/chapman/micm/config.json'
     filename_of_tuvx_configuration = 'musica_configurations/chapman/tuvx/config.json'
     filename_of_tuvx_micm_mapping_configuration = 'musica_configurations/chapman/tuvx_micm_mapping.json'
@@ -123,7 +125,8 @@ contains
       end do
     end do
 
-    call musica_ccpp_register(constituent_props, errmsg, errcode)
+    call musica_ccpp_register(constituent_props, number_of_micm_rate_parameters, &
+                              errmsg, errcode)
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3
@@ -308,6 +311,8 @@ contains
     logical                                          :: tmp_bool, has_profile
     integer                                          :: i_elem, i_col, i, j, k
 
+    integer                             :: number_of_micm_rate_parameters
+
     filename_of_micm_configuration = 'musica_configurations/chapman/micm/config.json'
     filename_of_tuvx_configuration = 'musica_configurations/chapman/tuvx/config.json'
     filename_of_tuvx_micm_mapping_configuration = 'musica_configurations/chapman/tuvx_micm_mapping.json'
@@ -323,7 +328,8 @@ contains
       end do
     end do
 
-    call musica_ccpp_register( constituent_props, errmsg, errcode )
+    call musica_ccpp_register( constituent_props, number_of_micm_rate_parameters, &
+                               errmsg, errcode )
     if (errcode /= 0) then
       write(*,*) trim(errmsg)
       stop 3

--- a/test/musica/tuvx/test_tuvx_gas_species.F90
+++ b/test/musica/tuvx/test_tuvx_gas_species.F90
@@ -18,7 +18,8 @@ contains
   subroutine calculate_gas_species_interfaces_and_densities( &
       molar_mass, dry_air_density, constituents, height_deltas, &
       is_O3, interfaces, densities)
-    use ccpp_kinds, only: kind_phys
+    use ccpp_kinds,       only: kind_phys
+    use musica_ccpp_util, only: AVOGADRO
 
     real(kind_phys), intent(in)    :: molar_mass
     real(kind_phys), intent(in)    :: dry_air_density(:)
@@ -29,15 +30,16 @@ contains
     real(kind_phys), intent(inout) :: densities(size(constituents) + 1)
 
     ! local variables
-    real(kind_phys) :: constituent_mol_per_cm_3(size(constituents)) ! mol cm-3
+    real(kind_phys) :: constituent_molec_per_cm_3(size(constituents)) ! molecule cm-3
     integer         :: num_vertical_levels
 
-    constituent_mol_per_cm_3(:) = constituents(:) * dry_air_density(:) / molar_mass / m_3_to_cm_3
+    constituent_molec_per_cm_3(:) = constituents(:) * dry_air_density(:) / molar_mass &
+                                    * AVOGADRO / m_3_to_cm_3
 
     num_vertical_levels = size(constituents)
-    interfaces(1) = constituent_mol_per_cm_3(num_vertical_levels)
-    interfaces(2:num_vertical_levels+1) = constituent_mol_per_cm_3(num_vertical_levels:1:-1)
-    interfaces(num_vertical_levels+2) = constituent_mol_per_cm_3(1)
+    interfaces(1) = constituent_molec_per_cm_3(num_vertical_levels)
+    interfaces(2:num_vertical_levels+1) = constituent_molec_per_cm_3(num_vertical_levels:1:-1)
+    interfaces(num_vertical_levels+2) = constituent_molec_per_cm_3(1)
 
     if ( is_O3 ) then
       densities(:) = height_deltas(:) * km_to_cm           &
@@ -65,6 +67,7 @@ contains
     use musica_ccpp_tuvx_load_species, only: index_dry_air, index_O2, index_O3, &
                                              SCALE_HEIGHT_DRY_AIR, SCALE_HEIGHT_O2, SCALE_HEIGHT_O3, &
                                              MOLAR_MASS_DRY_AIR, MOLAR_MASS_O2, MOLAR_MASS_O3
+    use musica_ccpp_util,              only: AVOGADRO
     use musica_ccpp_species,           only: tuvx_species_set, MUSICA_INT_UNASSIGNED
 
     integer,         parameter          :: NUM_COLUMNS = 2
@@ -183,6 +186,16 @@ contains
       do i = 1, size(dry_air_interfaces)
         ASSERT(dry_air_interfaces(i) == expected_dry_air_interfaces(i_col, i))
       end do
+      ! Hand-computed known-answer checks pin the conversion to number density
+      ! (molecule cm-3): omitting Avogadro's number (a ~6.0e23x underestimate
+      ! of all gas optical depths) is invisible to the mirrored-formula checks
+      ! above. Column 1 dry air, MW 0.0289644 kg mol-1:
+      !   layer 2: 0.5 kg/kg * 5.5 kg/m3 -> 5.71767e19 molecule cm-3 (interface 1)
+      !   layer 1: 0.4 kg/kg * 3.5 kg/m3 -> 2.91081e19 molecule cm-3 (interface 3)
+      if (i_col == 1) then
+        ASSERT_NEAR(dry_air_interfaces(1), 5.71767e19_kind_phys, 1.0e15_kind_phys)
+        ASSERT_NEAR(dry_air_interfaces(3), 2.91081e19_kind_phys, 1.0e15_kind_phys)
+      end if
       call dry_air_profile%get_layer_densities( dry_air_densities, error )
       ASSERT(error%is_success())
       do i = 1, size(dry_air_densities) - 1
@@ -190,11 +203,11 @@ contains
       end do
       ! the calculate_exo_layer_density call uses the scale height and the density of the uppermost
       ! layer to estimate the density above the column top, which affects the uppermost top value
-      ASSERT_NEAR(dry_air_densities(size(dry_air_densities)), expected_dry_air_densities(i_col, size(dry_air_densities)) * SCALE_HEIGHT_DRY_AIR * m_to_cm, ABS_ERROR)
+      ASSERT_NEAR(dry_air_densities(size(dry_air_densities)), expected_dry_air_densities(i_col, size(dry_air_densities)) * SCALE_HEIGHT_DRY_AIR * m_to_cm, ABS_ERROR * AVOGADRO)
       dry_air_exo_layer_density = dry_air_profile%get_exo_layer_density( error )
       ASSERT(error%is_success())
       expected_dry_air_exo_layer_density = expected_dry_air_densities(i_col, size(dry_air_densities)) * SCALE_HEIGHT_DRY_AIR * m_to_cm
-      ASSERT_NEAR(dry_air_exo_layer_density, expected_dry_air_exo_layer_density, ABS_ERROR)
+      ASSERT_NEAR(dry_air_exo_layer_density, expected_dry_air_exo_layer_density, ABS_ERROR * AVOGADRO)
 
       ! O2
       call O2_profile%get_edge_values( O2_interfaces, error )
@@ -207,11 +220,11 @@ contains
       do i = 1, size(O2_densities) - 1
         ASSERT(O2_densities(i) == expected_O2_densities(i_col, i))
       end do
-      ASSERT_NEAR(O2_densities(size(O2_densities)), expected_O2_densities(i_col, size(O2_densities)) * SCALE_HEIGHT_O2 * m_to_cm, ABS_ERROR)
+      ASSERT_NEAR(O2_densities(size(O2_densities)), expected_O2_densities(i_col, size(O2_densities)) * SCALE_HEIGHT_O2 * m_to_cm, ABS_ERROR * AVOGADRO)
       O2_exo_layer_density = O2_profile%get_exo_layer_density( error )
       ASSERT(error%is_success())
       expected_O2_exo_layer_density = expected_O2_densities(i_col, size(O2_densities)) * SCALE_HEIGHT_O2 * m_to_cm
-      ASSERT_NEAR(O2_exo_layer_density, expected_O2_exo_layer_density, ABS_ERROR)
+      ASSERT_NEAR(O2_exo_layer_density, expected_O2_exo_layer_density, ABS_ERROR * AVOGADRO)
 
       ! O3
       call O3_profile%get_edge_values( O3_interfaces, error )
@@ -224,11 +237,11 @@ contains
       do i = 1, size(O3_densities) - 1
         ASSERT(O3_densities(i) == expected_O3_densities(i_col, i))
       end do
-      ASSERT_NEAR(O3_densities(size(O3_densities)), expected_O3_densities(i_col, size(O3_densities)) * SCALE_HEIGHT_O3 * m_to_cm, ABS_ERROR)
+      ASSERT_NEAR(O3_densities(size(O3_densities)), expected_O3_densities(i_col, size(O3_densities)) * SCALE_HEIGHT_O3 * m_to_cm, ABS_ERROR * AVOGADRO)
       O3_exo_layer_density = O3_profile%get_exo_layer_density( error )
       ASSERT(error%is_success())
       expected_O3_exo_layer_density = expected_O3_densities(i_col, size(O3_densities)) * SCALE_HEIGHT_O3 * m_to_cm
-      ASSERT_NEAR(O3_exo_layer_density, expected_O3_exo_layer_density, ABS_ERROR)
+      ASSERT_NEAR(O3_exo_layer_density, expected_O3_exo_layer_density, ABS_ERROR * AVOGADRO)
     end do
 
     ! The gas species index starts at 2 because index 1 is reserved for cloud liquid


### PR DESCRIPTION
Tag name (The PR title should also include the tag name):
Originator(s): @jimmielin coauthored with `claude-fable:5`, `claude-fable:5.1`, reviewed by `claude-opus:4.8`

Description (include issue title and the keyword ['closes', 'fixes', 'resolves'] and issue number):
- Fixes two unit conversion issues in the MUSICA to CAM-SIMA interface.
- Splits schemes to `_photolysis` and `_chemistry` for modularity.

List all namelist files that were added or changed: N/A

List all files eliminated and why: N/A

List all files added and what they do:
```
A       schemes/musica/musica_ccpp_chemistry.F90
A       schemes/musica/musica_ccpp_chemistry.meta
A       schemes/musica/musica_ccpp_photolysis.F90
A       schemes/musica/musica_ccpp_photolysis.meta
  - split schemes so reaction rates can be added between them,
    increase modularity
```

List all existing files that have been modified, and describe the changes:
(Helpful git command: `git diff --name-status main...<your_branch_name>`)
```
M       schemes/musica/micm/musica_ccpp_micm.F90
  - thread through dry_air_density to extract_mixing_ratios_from_state

M       schemes/musica/micm/musica_ccpp_micm_util.F90
  - fix unit conversion

M       schemes/musica/tuvx/musica_ccpp_tuvx_gas_species.F90
  - fix unit conversion

M       test/musica/micm/test_micm_util.F90
M       test/musica/test_musica_api.F90
M       test/musica/test_musica_species.F90
M       test/musica/tuvx/test_tuvx_gas_species.F90
  - pin hand-calculated answers to tests to ensure correct units

M       schemes/musica/musica_ccpp.F90
M       schemes/musica/musica_ccpp.meta
  - export number of MICM rate parameters to framework
  - split into musica_ccpp_chemistry and musica_ccpp_photolysis schemes

M       schemes/musica/util/musica_ccpp_util.F90
  - protected setter for do_tuvx

M       suites/suite_musica.xml
M       test/musica/CMakeLists.txt
  - scheme split
```

List all automated tests that failed, as well as an explanation for why they weren't fixed:

Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?
Answer-changing only for MUSICA

If yes to the above question, describe how this code was validated with the new/modified features:
Hand-calculated answers are now pinned in test suite to ensure correctness
