### PR TITLE
Add TEMPO microphysics and Xu-Randall cloud fraction schemes to convection-permitting suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,9 @@
         fxrequired = AlwaysRequired
         fxtag = v1.9.2
         fxDONOTUSEurl = https://github.com/earth-system-radiation/rte-rrtmgp.git
+[submodule "tempo"]
+	path = schemes/tempo/tempo
+	url = https://github.com/NCAR/TEMPO.git
+	fxtag = tempo_v3.1.2
+	fxrequired = AlwaysRequired
+	fxDONOTUSEurl = https://github.com/NCAR/TEMPO.git

--- a/schemes/mmm/ccpp_kind_types.F90
+++ b/schemes/mmm/ccpp_kind_types.F90
@@ -1,8 +1,8 @@
-!> The mere existence of this module is to satisfy the misdirected dependency of the MMM physics,
-!> which inexplicably depends on `ccpp_kind_types` instead of `ccpp_kinds`.
+!> The MMM physics depends on `ccpp_kind_types` for real kind parameters
+!> instead of `ccpp_kinds`.
 module ccpp_kind_types
     use ccpp_kinds, only: kind_phys
-    use iso_fortran_env, only: kind_phys8 => real64
+    use, intrinsic :: iso_fortran_env, only: kind_phys8 => real64
 
     implicit none
 

--- a/schemes/mmm/cldfra_xu_randall.F90
+++ b/schemes/mmm/cldfra_xu_randall.F90
@@ -1,0 +1,104 @@
+module cldfra_xu_randall
+    implicit none
+
+    private
+    public :: cldfra_xu_randall_run
+contains
+    !> This subroutine implements the Xu-Randall cloud fraction scheme from Xu and Randall (1996).
+    !> See doi:10.1175/1520-0469(1996)053<3084:ASCPFU>2.0.CO;2 for details.
+    !>
+    !> This CCPP-conformant version is based on the implementations in MPAS (`calc_cldfraction`) and WRF (`cal_cldfra1`).
+    !>
+    !> \section arg_table_cldfra_xu_randall_run Argument Table
+    !! \htmlinclude cldfra_xu_randall_run.html
+    pure subroutine cldfra_xu_randall_run( &
+            ncol, pver, epsilon, svpt0, &
+            pres, temp, qv, qc, qi, qs, &
+            cldfra, relhum, &
+            errmsg, errflg)
+        use ccpp_kinds, only: kind_phys
+
+        integer, intent(in) :: ncol, pver
+        real(kind_phys), intent(in) :: epsilon, svpt0, &
+                                       pres(:, :), temp(:, :), qv(:, :), qc(:, :), qi(:, :), qs(:, :)
+        real(kind_phys), intent(out) :: cldfra(:, :), relhum(:, :)
+        character(*), intent(out) :: errmsg
+        integer, intent(out) :: errflg
+
+        ! Constants from Xu and Randall (1996).
+        real(kind_phys), parameter :: alpha0 = 100.0_kind_phys ! Correspond to the $\alpha_0$ constant.
+        real(kind_phys), parameter :: gamma  = 0.49_kind_phys  ! Correspond to the $\gamma$ constant.
+        real(kind_phys), parameter :: p      = 0.25_kind_phys  ! Correspond to the $p$ constant.
+
+        ! Constants from Equation 6 in Murray (1967).
+        ! See doi:10.1175/1520-0450(1967)006<0203:OTCOSV>2.0.CO;2 for details.
+        real(kind_phys), parameter :: svp1  = 0.61078_kind_phys
+        real(kind_phys), parameter :: svp2  = 17.2693882_kind_phys
+        real(kind_phys), parameter :: svp3  = 35.86_kind_phys
+        real(kind_phys), parameter :: svpi2 = 21.8745584_kind_phys
+        real(kind_phys), parameter :: svpi3 = 7.66_kind_phys
+
+        ! Implementation-defined thresholds.
+        real(kind_phys), parameter :: qcldmin    = 1.0E-12_kind_phys
+        real(kind_phys), parameter :: relhumcrit = 1.0_kind_phys ! Critical RH to be considered grid-scale saturation.
+
+        integer :: i, k
+        real(kind_phys) :: esw, esi, qvsw, qvsi, qcld, weight, qvs
+        real(kind_phys) :: exponent, satdef
+
+        cldfra(:, :) = 0.0_kind_phys
+        relhum(:, :) = 0.0_kind_phys
+
+        do k = 1, pver
+            do i = 1, ncol
+                ! Saturation vapor pressures wrt water and ice.
+                esw = 1000.0_kind_phys * svp1 * exp(svp2  * (temp(i, k) - svpt0) / (temp(i, k) - svp3 ))
+                esi = 1000.0_kind_phys * svp1 * exp(svpi2 * (temp(i, k) - svpt0) / (temp(i, k) - svpi3))
+
+                ! Saturation vapor mixing ratios wrt water and ice.
+                qvsw = epsilon * esw / (pres(i, k) - esw)
+                qvsi = epsilon * esi / (pres(i, k) - esi)
+
+                ! "Cloudy" mixing ratio, which corresponds to the $\bar{q_l}$ term in Xu and Randall (1996).
+                qcld = qc(i, k) + qi(i, k) + qs(i, k)
+
+                ! "Icy" weight of the cloudy mixing ratio.
+                if (qcld < qcldmin) then
+                    weight = 0.0_kind_phys
+                else
+                    weight = (qi(i, k) + qs(i, k)) / qcld
+                end if
+
+                ! Weighted saturation vapor mixing ratio and RH.
+                qvs = (1.0_kind_phys - weight) * qvsw + weight * qvsi
+                relhum(i, k) = qv(i, k) / qvs
+
+                if (qcld < qcldmin) then
+                    ! Assume that the cloud fraction is 0 when the cloudy mixing ratio is below the minimum threshold.
+                    cldfra(i, k) = 0.0_kind_phys
+                else if (relhum(i, k) >= relhumcrit) then
+                    ! Assume that the cloud fraction is 1 when the RH exceeds the critical RH.
+                    ! This is the RH >= 1 branch of Equation 4 in Xu and Randall (1996).
+                    cldfra(i, k) = 1.0_kind_phys
+                else
+                    ! Saturation deficiency scaled by the critical RH.
+                    ! 1.0E-10 is an implementation-defined limit.
+                    satdef = max(1.0E-10_kind_phys, relhumcrit * qvs - qv(i, k))
+                    relhum(i, k) = max(1.0E-10_kind_phys, relhum(i, k))
+
+                    ! This is the RH < 1 branch of Equation 4 in Xu and Randall (1996).
+                    ! 1.0E-3 is an implementation-defined limit.
+                    exponent = -alpha0 * qcld / (satdef**gamma)
+                    cldfra(i, k) = ((relhum(i, k) / relhumcrit)**p) * (1.0_kind_phys - max(1.0E-3_kind_phys, exp(exponent)))
+
+                    if (cldfra(i, k) < 0.01_kind_phys) then
+                        cldfra(i, k) = 0.0_kind_phys
+                    end if
+                end if
+            end do
+        end do
+
+        errmsg = ''
+        errflg = 0
+    end subroutine cldfra_xu_randall_run
+end module cldfra_xu_randall

--- a/schemes/mmm/cldfra_xu_randall.meta
+++ b/schemes/mmm/cldfra_xu_randall.meta
@@ -1,0 +1,93 @@
+[ccpp-table-properties]
+  name = cldfra_xu_randall
+  type = scheme
+
+[ccpp-arg-table]
+  name = cldfra_xu_randall_run
+  type = scheme
+[ ncol ]
+  standard_name = horizontal_loop_extent
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
+[ pver ]
+  standard_name = vertical_layer_dimension
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
+[ epsilon ]
+  standard_name = ratio_of_water_vapor_to_dry_air_molecular_weights
+  units = 1
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ svpt0 ]
+  standard_name = freezing_point_of_water
+  units = K
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ pres ]
+  standard_name = air_pressure
+  units = Pa
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ temp ]
+  standard_name = air_temperature
+  units = K
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qv ]
+  standard_name = water_vapor_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qc ]
+  standard_name = cloud_liquid_water_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qi ]
+  standard_name = cloud_ice_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qs ]
+  standard_name = snow_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ cldfra ]
+  standard_name = cloud_area_fraction
+  units = fraction
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ relhum ]
+  standard_name = relative_humidity
+  units = fraction
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  type = character | kind = len=*
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/mmm/cldfra_xu_randall_diag.F90
+++ b/schemes/mmm/cldfra_xu_randall_diag.F90
@@ -1,0 +1,40 @@
+module cldfra_xu_randall_diag
+    implicit none
+
+    private
+    public :: cldfra_xu_randall_diagnostics_init
+    public :: cldfra_xu_randall_diagnostics_run
+contains
+    !> \section arg_table_cldfra_xu_randall_diagnostics_init Argument Table
+    !! \htmlinclude cldfra_xu_randall_diagnostics_init.html
+    subroutine cldfra_xu_randall_diagnostics_init( &
+            errmsg, errflg)
+        use cam_history, only: history_add_field
+
+        character(*), intent(out) :: errmsg
+        integer, intent(out) :: errflg
+
+        call history_add_field('cldfra_xu_randall', 'cloud_area_fraction', 'lev', 'avg', 'fraction')
+
+        errmsg = ''
+        errflg = 0
+    end subroutine cldfra_xu_randall_diagnostics_init
+
+    !> \section arg_table_cldfra_xu_randall_diagnostics_run Argument Table
+    !! \htmlinclude cldfra_xu_randall_diagnostics_run.html
+    subroutine cldfra_xu_randall_diagnostics_run( &
+            cldfra, &
+            errmsg, errflg)
+        use cam_history, only: history_out_field
+        use ccpp_kinds, only: kind_phys
+
+        real(kind_phys), intent(in) :: cldfra(:, :)
+        character(*), intent(out) :: errmsg
+        integer, intent(out) :: errflg
+
+        call history_out_field('cldfra_xu_randall', cldfra)
+
+        errmsg = ''
+        errflg = 0
+    end subroutine cldfra_xu_randall_diagnostics_run
+end module cldfra_xu_randall_diag

--- a/schemes/mmm/cldfra_xu_randall_diag.meta
+++ b/schemes/mmm/cldfra_xu_randall_diag.meta
@@ -1,0 +1,45 @@
+[ccpp-table-properties]
+  name = cldfra_xu_randall_diagnostics
+  type = scheme
+
+[ccpp-arg-table]
+  name = cldfra_xu_randall_diagnostics_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  type = character | kind = len=*
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+
+[ccpp-arg-table]
+  name = cldfra_xu_randall_diagnostics_run
+  type = scheme
+[ cldfra ]
+  standard_name = cloud_area_fraction
+  units = fraction
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  type = character | kind = len=*
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/mmm/mmm_physics_compat.F90
+++ b/schemes/mmm/mmm_physics_compat.F90
@@ -70,7 +70,7 @@ contains
         real(kind_phys), intent(in) :: dt, &
                                        theta_curr(:, :), theta_prev(:, :), qv_curr(:, :), qv_prev(:, :), &
                                        icefrac(:), xice_threshold, landfrac(:)
-        character(256), intent(out) :: scheme_name
+        character(*), intent(out) :: scheme_name
         real(kind_phys), intent(out) :: rthdynten(:, :), rqvdynten(:, :), &
                                         xland(:)
         character(*), intent(out) :: errmsg

--- a/schemes/mmm/mmm_physics_compat.F90
+++ b/schemes/mmm/mmm_physics_compat.F90
@@ -105,25 +105,29 @@ contains
     pure subroutine mmm_physics_accumulate_tendencies_timestep_init( &
             dudt, dvdt, dtdt, &
             rublten, rucuten, rvblten, rvcuten, &
-            rthblten, rthcuten, rthratenlw, rthratensw, &
-            rqvblten, rqvcuten, &
-            rqcblten, rncblten, rqccuten, &
-            rqiblten, rniblten, rqicuten, &
-            rqsblten, &
+            rthblten, rthcuten, rthmpten, rthratenlw, rthratensw, &
+            rqvblten, rqvcuten, rqvmpten, &
+            rqcblten, rncblten, rqccuten, rqcmpten, rncmpten, &
+            rqrmpten, rnrmpten, &
+            rqiblten, rniblten, rqicuten, rqimpten, rnimpten, &
+            rqsblten, rqsmpten, &
+            rqgmpten, rngmpten, rvolgmpten, &
             rozblten, &
-            rnwfablten, rnifablten, rnbcablten, &
+            rnwfablten, rnwfampten, rnifablten, rnifampten, rnbcablten, &
             errmsg, errflg)
         use ccpp_kinds, only: kind_phys
 
         real(kind_phys), intent(out) :: dudt(:, :), dvdt(:, :), dtdt(:, :), &
                                         rublten(:, :), rucuten(:, :), rvblten(:, :), rvcuten(:, :), &
-                                        rthblten(:, :), rthcuten(:, :), rthratenlw(:, :), rthratensw(:, :), &
-                                        rqvblten(:, :), rqvcuten(:, :), &
-                                        rqcblten(:, :), rncblten(:, :), rqccuten(:, :), &
-                                        rqiblten(:, :), rniblten(:, :), rqicuten(:, :), &
-                                        rqsblten(:, :), &
+                                        rthblten(:, :), rthcuten(:, :), rthmpten(:, :), rthratenlw(:, :), rthratensw(:, :), &
+                                        rqvblten(:, :), rqvcuten(:, :), rqvmpten(:, :), &
+                                        rqcblten(:, :), rncblten(:, :), rqccuten(:, :), rqcmpten(:, :), rncmpten(:, :), &
+                                        rqrmpten(:, :), rnrmpten(:, :), &
+                                        rqiblten(:, :), rniblten(:, :), rqicuten(:, :), rqimpten(:, :), rnimpten(:, :), &
+                                        rqsblten(:, :), rqsmpten(:, :), &
+                                        rqgmpten(:, :), rngmpten(:, :), rvolgmpten(:, :), &
                                         rozblten(:, :), &
-                                        rnwfablten(:, :), rnifablten(:, :), rnbcablten(:, :)
+                                        rnwfablten(:, :), rnwfampten(:, :), rnifablten(:, :), rnifampten(:, :), rnbcablten(:, :)
         character(*), intent(out) :: errmsg
         integer, intent(out) :: errflg
 
@@ -145,26 +149,42 @@ contains
 
         rthblten(:, :) = 0.0_kind_phys
         rthcuten(:, :) = 0.0_kind_phys
+        rthmpten(:, :) = 0.0_kind_phys
         rthratenlw(:, :) = 0.0_kind_phys
         rthratensw(:, :) = 0.0_kind_phys
 
         rqvblten(:, :) = 0.0_kind_phys
         rqvcuten(:, :) = 0.0_kind_phys
+        rqvmpten(:, :) = 0.0_kind_phys
 
         rqcblten(:, :) = 0.0_kind_phys
         rncblten(:, :) = 0.0_kind_phys
         rqccuten(:, :) = 0.0_kind_phys
+        rqcmpten(:, :) = 0.0_kind_phys
+        rncmpten(:, :) = 0.0_kind_phys
+
+        rqrmpten(:, :) = 0.0_kind_phys
+        rnrmpten(:, :) = 0.0_kind_phys
 
         rqiblten(:, :) = 0.0_kind_phys
         rniblten(:, :) = 0.0_kind_phys
         rqicuten(:, :) = 0.0_kind_phys
+        rqimpten(:, :) = 0.0_kind_phys
+        rnimpten(:, :) = 0.0_kind_phys
 
         rqsblten(:, :) = 0.0_kind_phys
+        rqsmpten(:, :) = 0.0_kind_phys
+
+        rqgmpten(:, :) = 0.0_kind_phys
+        rngmpten(:, :) = 0.0_kind_phys
+        rvolgmpten(:, :) = 0.0_kind_phys
 
         rozblten(:, :) = 0.0_kind_phys
 
         rnwfablten(:, :) = 0.0_kind_phys
+        rnwfampten(:, :) = 0.0_kind_phys
         rnifablten(:, :) = 0.0_kind_phys
+        rnifampten(:, :) = 0.0_kind_phys
         rnbcablten(:, :) = 0.0_kind_phys
     end subroutine mmm_physics_accumulate_tendencies_timestep_init
 
@@ -173,31 +193,37 @@ contains
     pure subroutine mmm_physics_accumulate_tendencies_run( &
             dt, exner, &
             dudt, dvdt, dtdt, &
-            theta, qv, qc, qi, qs, ozone, &
-            nc, ni, nwfa, nifa, nbca, &
+            theta, qv, qc, qr, qi, qs, qg, ozone, &
+            nc, nr, ni, ng, nwfa, nifa, nbca, &
+            volg, &
             rublten, rucuten, rvblten, rvcuten, &
-            rthblten, rthcuten, rthratenlw, rthratensw, &
-            rqvblten, rqvcuten, &
-            rqcblten, rncblten, rqccuten, &
-            rqiblten, rniblten, rqicuten, &
-            rqsblten, &
+            rthblten, rthcuten, rthmpten, rthratenlw, rthratensw, &
+            rqvblten, rqvcuten, rqvmpten, &
+            rqcblten, rncblten, rqccuten, rqcmpten, rncmpten, &
+            rqrmpten, rnrmpten, &
+            rqiblten, rniblten, rqicuten, rqimpten, rnimpten, &
+            rqsblten, rqsmpten, &
+            rqgmpten, rngmpten, rvolgmpten, &
             rozblten, &
-            rnwfablten, rnifablten, rnbcablten, &
+            rnwfablten, rnwfampten, rnifablten, rnifampten, rnbcablten, &
             errmsg, errflg)
         use ccpp_kinds, only: kind_phys
 
         real(kind_phys), intent(in) :: dt, exner(:, :)
         real(kind_phys), intent(inout) :: dudt(:, :), dvdt(:, :), dtdt(:, :), &
-                                          theta(:, :), qv(:, :), qc(:, :), qi(:, :), qs(:, :), ozone(:, :), &
-                                          nc(:, :), ni(:, :), nwfa(:, :), nifa(:, :), nbca(:, :), &
+                                          theta(:, :), qv(:, :), qc(:, :), qr(:, :), qi(:, :), qs(:, :), qg(:, :), ozone(:, :), &
+                                          nc(:, :), nr(:, :), ni(:, :), ng(:, :), nwfa(:, :), nifa(:, :), nbca(:, :), &
+                                          volg(:, :), &
                                           rublten(:, :), rucuten(:, :), rvblten(:, :), rvcuten(:, :), &
-                                          rthblten(:, :), rthcuten(:, :), rthratenlw(:, :), rthratensw(:, :), &
-                                          rqvblten(:, :), rqvcuten(:, :), &
-                                          rqcblten(:, :), rncblten(:, :), rqccuten(:, :), &
-                                          rqiblten(:, :), rniblten(:, :), rqicuten(:, :), &
-                                          rqsblten(:, :), &
+                                          rthblten(:, :), rthcuten(:, :), rthmpten(:, :), rthratenlw(:, :), rthratensw(:, :), &
+                                          rqvblten(:, :), rqvcuten(:, :), rqvmpten(:, :), &
+                                          rqcblten(:, :), rncblten(:, :), rqccuten(:, :), rqcmpten(:, :), rncmpten(:, :), &
+                                          rqrmpten(:, :), rnrmpten(:, :), &
+                                          rqiblten(:, :), rniblten(:, :), rqicuten(:, :), rqimpten(:, :), rnimpten(:, :), &
+                                          rqsblten(:, :), rqsmpten(:, :), &
+                                          rqgmpten(:, :), rngmpten(:, :), rvolgmpten(:, :), &
                                           rozblten(:, :), &
-                                          rnwfablten(:, :), rnifablten(:, :), rnbcablten(:, :)
+                                          rnwfablten(:, :), rnwfampten(:, :), rnifablten(:, :), rnifampten(:, :), rnbcablten(:, :)
         character(*), intent(out) :: errmsg
         integer, intent(out) :: errflg
 
@@ -207,20 +233,27 @@ contains
         ! Accumulate the states and tendencies for feeding back to CAM-SIMA.
         dudt(:, :) = dudt(:, :) + (rublten(:, :) + rucuten(:, :))
         dvdt(:, :) = dvdt(:, :) + (rvblten(:, :) + rvcuten(:, :))
-        dtdt(:, :) = dtdt(:, :) + (rthblten(:, :) + rthcuten(:, :) + rthratenlw(:, :) + rthratensw(:, :)) * exner(:, :)
+        dtdt(:, :) = dtdt(:, :) + (rthblten(:, :) + rthcuten(:, :) + rthmpten(:, :) + rthratenlw(:, :) + rthratensw(:, :)) * &
+            exner(:, :)
 
-        theta(:, :) = theta(:, :) + (rthblten(:, :) + rthcuten(:, :) + rthratenlw(:, :) + rthratensw(:, :)) * dt
-        qv(:, :) = qv(:, :) + (rqvblten(:, :) + rqvcuten(:, :)) * dt
-        qc(:, :) = qc(:, :) + (rqcblten(:, :) + rqccuten(:, :)) * dt
-        qi(:, :) = qi(:, :) + (rqiblten(:, :) + rqicuten(:, :)) * dt
-        qs(:, :) = qs(:, :) + rqsblten(:, :) * dt
+        theta(:, :) = theta(:, :) + (rthblten(:, :) + rthcuten(:, :) + rthmpten(:, :) + rthratenlw(:, :) + rthratensw(:, :)) * dt
+        qv(:, :) = qv(:, :) + (rqvblten(:, :) + rqvcuten(:, :) + rqvmpten(:, :)) * dt
+        qc(:, :) = qc(:, :) + (rqcblten(:, :) + rqccuten(:, :) + rqcmpten(:, :)) * dt
+        qr(:, :) = qr(:, :) + rqrmpten(:, :) * dt
+        qi(:, :) = qi(:, :) + (rqiblten(:, :) + rqicuten(:, :) + rqimpten(:, :)) * dt
+        qs(:, :) = qs(:, :) + (rqsblten(:, :) + rqsmpten(:, :)) * dt
+        qg(:, :) = qg(:, :) + rqgmpten(:, :) * dt
         ozone(:, :) = ozone(:, :) + rozblten(:, :) * dt
 
-        nc(:, :) = nc(:, :) + rncblten(:, :) * dt
-        ni(:, :) = ni(:, :) + rniblten(:, :) * dt
-        nwfa(:, :) = nwfa(:, :) + rnwfablten(:, :) * dt
-        nifa(:, :) = nifa(:, :) + rnifablten(:, :) * dt
+        nc(:, :) = nc(:, :) + (rncblten(:, :) + rncmpten(:, :)) * dt
+        nr(:, :) = nr(:, :) + rnrmpten(:, :) * dt
+        ni(:, :) = ni(:, :) + (rniblten(:, :) + rnimpten(:, :)) * dt
+        ng(:, :) = ng(:, :) + rngmpten(:, :) * dt
+        nwfa(:, :) = nwfa(:, :) + (rnwfablten(:, :) + rnwfampten(:, :)) * dt
+        nifa(:, :) = nifa(:, :) + (rnifablten(:, :) + rnifampten(:, :)) * dt
         nbca(:, :) = nbca(:, :) + rnbcablten(:, :) * dt
+
+        volg(:, :) = volg(:, :) + rvolgmpten(:, :) * dt
 
         ! After accumulating, zero out the tendencies collected from MMM physics schemes to make this subroutine idempotent,
         ! preventing repeated application of the same tendencies.
@@ -231,26 +264,42 @@ contains
 
         rthblten(:, :) = 0.0_kind_phys
         rthcuten(:, :) = 0.0_kind_phys
+        rthmpten(:, :) = 0.0_kind_phys
         rthratenlw(:, :) = 0.0_kind_phys
         rthratensw(:, :) = 0.0_kind_phys
 
         rqvblten(:, :) = 0.0_kind_phys
         rqvcuten(:, :) = 0.0_kind_phys
+        rqvmpten(:, :) = 0.0_kind_phys
 
         rqcblten(:, :) = 0.0_kind_phys
         rncblten(:, :) = 0.0_kind_phys
         rqccuten(:, :) = 0.0_kind_phys
+        rqcmpten(:, :) = 0.0_kind_phys
+        rncmpten(:, :) = 0.0_kind_phys
+
+        rqrmpten(:, :) = 0.0_kind_phys
+        rnrmpten(:, :) = 0.0_kind_phys
 
         rqiblten(:, :) = 0.0_kind_phys
         rniblten(:, :) = 0.0_kind_phys
         rqicuten(:, :) = 0.0_kind_phys
+        rqimpten(:, :) = 0.0_kind_phys
+        rnimpten(:, :) = 0.0_kind_phys
 
         rqsblten(:, :) = 0.0_kind_phys
+        rqsmpten(:, :) = 0.0_kind_phys
+
+        rqgmpten(:, :) = 0.0_kind_phys
+        rngmpten(:, :) = 0.0_kind_phys
+        rvolgmpten(:, :) = 0.0_kind_phys
 
         rozblten(:, :) = 0.0_kind_phys
 
         rnwfablten(:, :) = 0.0_kind_phys
+        rnwfampten(:, :) = 0.0_kind_phys
         rnifablten(:, :) = 0.0_kind_phys
+        rnifampten(:, :) = 0.0_kind_phys
         rnbcablten(:, :) = 0.0_kind_phys
     end subroutine mmm_physics_accumulate_tendencies_run
 

--- a/schemes/mmm/mmm_physics_compat.meta
+++ b/schemes/mmm/mmm_physics_compat.meta
@@ -234,6 +234,12 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = out
+[ rthmpten ]
+  standard_name = tendency_of_air_potential_temperature_due_to_microphysics
+  units = K s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
 [ rthratenlw ]
   standard_name = tendency_of_air_potential_temperature_due_to_longwave_radiation
   units = K s-1
@@ -258,6 +264,12 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = out
+[ rqvmpten ]
+  standard_name = tendency_of_water_vapor_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
 [ rqcblten ]
   standard_name = tendency_of_cloud_liquid_water_mixing_ratio_wrt_dry_air_due_to_pbl_processes
   units = kg kg-1 s-1
@@ -273,6 +285,30 @@
 [ rqccuten ]
   standard_name = tendency_of_cloud_liquid_water_mixing_ratio_wrt_dry_air_due_to_convection
   units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rqcmpten ]
+  standard_name = tendency_of_cloud_liquid_water_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rncmpten ]
+  standard_name = tendency_of_mass_number_concentration_of_cloud_liquid_water_droplets_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rqrmpten ]
+  standard_name = tendency_of_rain_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rnrmpten ]
+  standard_name = tendency_of_mass_number_concentration_of_rain_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = out
@@ -294,8 +330,44 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = out
+[ rqimpten ]
+  standard_name = tendency_of_cloud_ice_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rnimpten ]
+  standard_name = tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
 [ rqsblten ]
   standard_name = tendency_of_snow_mixing_ratio_wrt_dry_air_due_to_pbl_processes
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rqsmpten ]
+  standard_name = tendency_of_snow_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rngmpten ]
+  standard_name = tendency_of_mass_number_concentration_of_graupel_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rvolgmpten ]
+  standard_name = tendency_of_graupel_volume_in_dry_air_due_to_microphysics
+  units = m3 kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rqgmpten ]
+  standard_name = tendency_of_graupel_mixing_ratio_wrt_dry_air_due_to_microphysics
   units = kg kg-1 s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension)
@@ -312,8 +384,20 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = out
+[ rnwfampten ]
+  standard_name = tendency_of_mass_number_concentration_of_hygroscopic_aerosols_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
 [ rnifablten ]
   standard_name = tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_dry_air_due_to_pbl_processes
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = out
+[ rnifampten ]
+  standard_name = tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_dry_air_due_to_microphysics
   units = kg-1 s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension)
@@ -390,6 +474,12 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
+[ qr ]
+  standard_name = rain_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
 [ qi ]
   standard_name = cloud_ice_mixing_ratio_wrt_dry_air
   units = kg kg-1
@@ -398,6 +488,12 @@
   intent = inout
 [ qs ]
   standard_name = snow_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ qg ]
+  standard_name = graupel_mixing_ratio_wrt_dry_air
   units = kg kg-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -416,8 +512,22 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
   advected = True
+[ nr ]
+  standard_name = mass_number_concentration_of_rain_in_dry_air
+  units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+  advected = True
 [ ni ]
   standard_name = mass_number_concentration_of_cloud_ice_water_crystals_in_dry_air
+  units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+  advected = True
+[ ng ]
+  standard_name = mass_number_concentration_of_graupel_in_dry_air
   units = kg-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -440,6 +550,13 @@
 [ nbca ]
   standard_name = mass_number_concentration_of_hydrophobic_black_carbon_in_dry_air
   units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+  advected = True
+[ volg ]
+  standard_name = graupel_volume_in_dry_air
+  units = m3 kg-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
@@ -480,6 +597,12 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
+[ rthmpten ]
+  standard_name = tendency_of_air_potential_temperature_due_to_microphysics
+  units = K s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
 [ rthratenlw ]
   standard_name = tendency_of_air_potential_temperature_due_to_longwave_radiation
   units = K s-1
@@ -504,6 +627,12 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
+[ rqvmpten ]
+  standard_name = tendency_of_water_vapor_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
 [ rqcblten ]
   standard_name = tendency_of_cloud_liquid_water_mixing_ratio_wrt_dry_air_due_to_pbl_processes
   units = kg kg-1 s-1
@@ -519,6 +648,30 @@
 [ rqccuten ]
   standard_name = tendency_of_cloud_liquid_water_mixing_ratio_wrt_dry_air_due_to_convection
   units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rqcmpten ]
+  standard_name = tendency_of_cloud_liquid_water_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rncmpten ]
+  standard_name = tendency_of_mass_number_concentration_of_cloud_liquid_water_droplets_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rqrmpten ]
+  standard_name = tendency_of_rain_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rnrmpten ]
+  standard_name = tendency_of_mass_number_concentration_of_rain_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
@@ -540,9 +693,45 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
+[ rqimpten ]
+  standard_name = tendency_of_cloud_ice_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rnimpten ]
+  standard_name = tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
 [ rqsblten ]
   standard_name = tendency_of_snow_mixing_ratio_wrt_dry_air_due_to_pbl_processes
   units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rqsmpten ]
+  standard_name = tendency_of_snow_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rqgmpten ]
+  standard_name = tendency_of_graupel_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rngmpten ]
+  standard_name = tendency_of_mass_number_concentration_of_graupel_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rvolgmpten ]
+  standard_name = tendency_of_graupel_volume_in_dry_air_due_to_microphysics
+  units = m3 kg-1 s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
@@ -558,8 +747,20 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
+[ rnwfampten ]
+  standard_name = tendency_of_mass_number_concentration_of_hygroscopic_aerosols_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
 [ rnifablten ]
   standard_name = tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_dry_air_due_to_pbl_processes
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+[ rnifampten ]
+  standard_name = tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_dry_air_due_to_microphysics
   units = kg-1 s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/schemes/mmm/mmm_physics_compat.meta
+++ b/schemes/mmm/mmm_physics_compat.meta
@@ -135,7 +135,7 @@
 [ scheme_name ]
   standard_name = scheme_name
   units = none
-  type = character | kind = len=256
+  type = character | kind = len=*
   dimensions = ()
   intent = out
 [ rthdynten ]

--- a/schemes/tempo/machine.F90
+++ b/schemes/tempo/machine.F90
@@ -1,0 +1,12 @@
+!> The TEMPO microphysics scheme depends on `machine` for real kind parameters
+!> instead of `ccpp_kinds`.
+module machine
+    use ccpp_kinds, only: kind_phys
+    use, intrinsic :: iso_fortran_env, only: kind_sngl_prec => real32, kind_dbl_prec => real64
+
+    implicit none
+
+    private
+    public :: kind_phys
+    public :: kind_sngl_prec, kind_dbl_prec
+end module machine

--- a/schemes/tempo/module_mp_tempo_cfgs.F90
+++ b/schemes/tempo/module_mp_tempo_cfgs.F90
@@ -1,0 +1,66 @@
+!> This module contains the default configuration for the TEMPO microphysics scheme in the form of Fortran derived types,
+!> overriding the upstream counterpart.
+module module_mp_tempo_cfgs
+    implicit none
+
+    private
+    public :: ty_tempo_cfgs, ty_tempo_table_cfgs
+
+    !> \section arg_table_ty_tempo_cfgs Argument Table
+    !! \htmlinclude ty_tempo_cfgs.html
+    type :: ty_tempo_cfgs
+        logical :: aerosolaware_flag = .true. !! flag to run aerosol-aware microphysics
+        logical :: hailaware_flag = .true. !! flag to run hail-aware microphysics
+        logical :: ml_for_bl_nc_flag = .false. !! flag to run machine-learning prediction for subgrid cloud number concentration
+        logical :: ml_for_nc_flag = .false. !! flag to run machine-learning prediction for tempo cloud number concentration
+        logical :: semi_sedi_flag = .false. !! flag for semi-lagrangian sedimentation
+        logical :: refl10cm_from_melting_flag = .false. !! flag to calculate reflectivity for melting snow and graupel
+        logical :: turn_off_micro_flag = .false. !! flag to turn off all microphysical processes
+        logical :: cloud_condensation_flag = .true. !! flag to control cloud condensation
+        logical :: verbose = .false. !! flag to turn on verbose print statements
+        logical :: check_tables = .false. !! flag to turn on check for lookup tables
+        character(32) :: single_moment_nc_opt = 'land' !! option for single moment cloud number concentration when land input is not present (options include 'land' that uses the parameter nt_c_l, 'ocean' that uses nt_c_o, or string value in m^-3, e.g. '10.e6')
+        ! flags to turn on/off diagnostic output
+        logical :: refl10cm_flag = .true. !! flag to output 10cm reflectivity
+        logical :: re_cloud_flag = .true. !! flag to output cloud effective radius
+        logical :: re_ice_flag = .true. !! flag to output ice effective radius
+        logical :: re_snow_flag = .true. !! flag to output snow effective radius
+        logical :: max_hail_diameter_flag = .false. !! flag to output maximum hail diameter
+        logical :: rain_med_vol_diam_flag = .false. !! flag to output median volume diameter for rain
+        logical :: graupel_med_vol_diam_flag = .false. !! flag to output median volume diameter for graupel
+        logical :: cloud_number_mixing_ratio_flag = .false. !! flag to output cloud number mixing ratio
+    contains
+        procedure :: get_nc_val => resolve_nc_value
+    end type
+
+    type :: ty_tempo_table_cfgs
+        character(100) :: ccn_table_name = 'ccn_activate.bin' !! ccn table name
+        character(100) :: qrqg_table_name = 'qr_acr_qg_data_tempo_v3' !! rain-graupel collection table name
+        character(100) :: qrqs_table_name = 'qr_acr_qs_data_tempo_v3' !! rain-snow collection table name
+        character(100) :: freezewater_table_name = 'freeze_water_data_tempo_v3' !! freeze water collection table name
+    end type
+contains
+    pure function resolve_nc_value(this, val_land, val_ocean)
+        use ccpp_kinds, only: kind_phys
+
+        class(ty_tempo_cfgs), intent(in) :: this
+        real(kind_phys), intent(in) :: val_land, val_ocean
+        real(kind_phys) :: resolve_nc_value
+
+        character(100) :: cerr
+        integer :: ierr
+
+        select case (trim(adjustl(this % single_moment_nc_opt)))
+            case ('land')
+                resolve_nc_value = val_land
+            case ('ocean')
+                resolve_nc_value = val_ocean
+            case default
+                read(this % single_moment_nc_opt, *, iomsg=cerr, iostat=ierr) resolve_nc_value
+
+                if (ierr /= 0) then
+                    resolve_nc_value = val_land
+                end if
+        end select
+    end function resolve_nc_value
+end module module_mp_tempo_cfgs

--- a/schemes/tempo/module_mp_tempo_cfgs.meta
+++ b/schemes/tempo/module_mp_tempo_cfgs.meta
@@ -1,0 +1,7 @@
+[ccpp-table-properties]
+  name = ty_tempo_cfgs
+  type = ddt
+
+[ccpp-arg-table]
+  name = ty_tempo_cfgs
+  type = ddt

--- a/schemes/tempo/mp_tempo.F90
+++ b/schemes/tempo/mp_tempo.F90
@@ -1,0 +1,378 @@
+!> This module contains the interstitial schemes for the TEMPO microphysics scheme.
+module mp_tempo
+    implicit none
+
+    private
+    public :: mp_tempo_init
+    public :: mp_tempo_run
+contains
+    !> \section arg_table_mp_tempo_init Argument Table
+    !! \htmlinclude mp_tempo_init.html
+    subroutine mp_tempo_init( &
+            num_subcyc, &
+            aerosol_aware, hail_aware, refl_incl_melt, sat_adj, semi_lagr_sedi, &
+            con_pi, con_hvap, con_hfus, con_rv, con_rd, con_cp, con_t0c, con_rgas, con_rhow, &
+            tempo_cfgs, &
+            errmsg, errflg)
+        use ccpp_kinds, only: kind_phys
+        use module_mp_tempo_cfgs, only: ty_tempo_cfgs
+        use module_mp_tempo_driver, only: tempo_init
+        use module_mp_tempo_params, only: pi, lvap0, lfus, lsub, rv, rdry, cp, t0, r_uni, rho_w, &
+                                          initialize_parameters
+
+        integer, intent(in) :: num_subcyc
+        logical, intent(in) :: aerosol_aware, hail_aware, refl_incl_melt, sat_adj, semi_lagr_sedi
+        real(kind_phys), intent(in) :: con_pi, con_hvap, con_hfus, con_rv, con_rd, con_cp, con_t0c, con_rgas, con_rhow
+        type(ty_tempo_cfgs), intent(out) :: tempo_cfgs
+        character(*), intent(out) :: errmsg
+        integer, intent(out) :: errflg
+
+        errmsg = ''
+        errflg = 0
+
+        ! Check for logic errors in namelist options.
+
+        if (num_subcyc < 1) then
+            errmsg = 'num_subcyc must be positive.'
+            errflg = 1
+
+            return
+        end if
+
+        if (sat_adj) then
+            if (aerosol_aware .or. hail_aware) then
+                errmsg = 'sat_adj=.true. should only be run with aerosol_aware=.false. and hail_aware=.false.'
+                errflg = 1
+
+                return
+            end if
+        end if
+
+        call tempo_init( &
+            aerosolaware_flag=aerosol_aware, &
+            hailaware_flag=hail_aware, &
+            refl10cm_from_melting_flag=refl_incl_melt, &
+            cloud_condensation_flag=(.not. sat_adj), &
+            semi_sedi_flag=semi_lagr_sedi, &
+            tempo_cfgs=tempo_cfgs)
+
+        pi = con_pi
+        lvap0 = con_hvap
+        lfus = con_hfus
+        lsub = lvap0 + lfus
+        rv = con_rv
+        rdry = con_rd
+        cp = con_cp
+        t0 = con_t0c
+        ! Convert from J "kmol-1" K-1 to J "mol-1" K-1.
+        r_uni = con_rgas / 1000.0_kind_phys
+        rho_w = con_rhow
+
+        call initialize_parameters()
+    end subroutine mp_tempo_init
+
+    !> \section arg_table_mp_tempo_run Argument Table
+    !! \htmlinclude mp_tempo_run.html
+    subroutine mp_tempo_run( &
+            ncol, pver, curr_step, num_subcyc, &
+            initial_run, &
+            dtime_phys, &
+            dz, w, p, exner, th, &
+            qv, qc, qr, qi, qs, qg, nr, ni, &
+            nc, nwfa, nifa, nwfa2d, nifa2d, &
+            ng, volg, &
+            tempo_cfgs, &
+            rain, ice, snow, graupel, prcp, &
+            tend_th, tend_qv, tend_qc, tend_qr, tend_qi, tend_qs, tend_qg, tend_nr, tend_ni, &
+            frozen_fraction, refl10cm, re_cloud, re_ice, re_snow, &
+            tend_nc, tend_nwfa, tend_nifa, &
+            tend_ng, tend_volg, &
+            errmsg, errflg)
+        use ccpp_kinds, only: kind_phys
+        use module_mp_tempo_aerosols, only: init_water_friendly_aerosols, init_ice_friendly_aerosols
+        use module_mp_tempo_cfgs, only: ty_tempo_cfgs
+        use module_mp_tempo_driver, only: ty_tempo_driver_diags, &
+                                          tempo_aerosol_surface_emissions, tempo_run
+        use module_mp_tempo_params, only: eps, nain1
+
+        integer, intent(in) :: ncol, pver, curr_step, num_subcyc
+        logical, intent(in) :: initial_run
+        real(kind_phys), intent(in) :: dtime_phys
+        real(kind_phys), intent(in) :: dz(:, :), w(:, :), p(:, :), exner(:, :), th(:, :)
+        real(kind_phys), intent(in) :: qv(:, :), qc(:, :), qr(:, :), qi(:, :), qs(:, :), qg(:, :), nr(:, :), ni(:, :)
+        ! Only used when aerosol-aware.
+        real(kind_phys), intent(in) :: nc(:, :)
+        real(kind_phys), intent(inout) :: nwfa(:, :), nifa(:, :), nwfa2d(:), nifa2d(:)
+        ! Only used when hail-aware.
+        real(kind_phys), intent(in) :: ng(:, :), volg(:, :)
+        type(ty_tempo_cfgs), intent(in) :: tempo_cfgs
+
+        real(kind_phys), intent(out) :: rain(:), ice(:), snow(:), graupel(:), prcp(:)
+        real(kind_phys), intent(out) :: tend_th(:, :)
+        real(kind_phys), intent(out) :: tend_qv(:, :), tend_qc(:, :), tend_qr(:, :)
+        real(kind_phys), intent(out) :: tend_qi(:, :), tend_qs(:, :), tend_qg(:, :)
+        real(kind_phys), intent(out) :: tend_nr(:, :), tend_ni(:, :)
+        real(kind_phys), intent(out) :: frozen_fraction(:), refl10cm(:, :), re_cloud(:, :), re_ice(:, :), re_snow(:, :)
+        ! Only used when aerosol-aware.
+        real(kind_phys), intent(out) :: tend_nc(:, :), tend_nwfa(:, :), tend_nifa(:, :)
+        ! Only used when hail-aware.
+        real(kind_phys), intent(out) :: tend_ng(:, :), tend_volg(:, :)
+        character(*), intent(out) :: errmsg
+        integer, intent(out) :: errflg
+
+        integer :: i
+        integer :: ids, ide, jds, jde, kds, kde, &
+                   ims, ime, jms, jme, kms, kme, &
+                   its, ite, jts, jte, kts, kte
+        real(kind_phys) :: dtime_subcyc
+        ! TEMPO expects vertical indexes to be in ascending order from bottom to top of atmosphere,
+        ! which is the exact opposite to CAM-SIMA. Variables with the "_r" suffix have a reversed vertical dimension.
+        ! Variables with the "_1" suffix have an extra dimension of size 1. In TEMPO, 2d arrays are dimensioned (i, j) while
+        ! 3d arrays are dimensioned (i, k, j). Even if the j dimension is not used, it still needs to be 1.
+        real(kind_phys) :: dz_r1(ncol, pver, 1), w_r1(ncol, pver, 1), p_r1(ncol, pver, 1), exner_r1(ncol, pver, 1)
+        real(kind_phys) :: new_th_r1(ncol, pver, 1)
+        real(kind_phys) :: new_qv_r1(ncol, pver, 1), new_qc_r1(ncol, pver, 1), new_qr_r1(ncol, pver, 1)
+        real(kind_phys) :: new_qi_r1(ncol, pver, 1), new_qs_r1(ncol, pver, 1), new_qg_r1(ncol, pver, 1)
+        real(kind_phys) :: new_nr_r1(ncol, pver, 1), new_ni_r1(ncol, pver, 1)
+        ! Only used when aerosol-aware.
+        real(kind_phys), allocatable :: nwfa_r1(:, :, :)
+        real(kind_phys), allocatable :: nwfa2d_1(:, :)
+        real(kind_phys), allocatable :: new_nc_r1(:, :, :)
+        real(kind_phys), allocatable :: new_nwfa_r1(:, :, :)
+        real(kind_phys), allocatable :: new_nifa_r1(:, :, :)
+        ! Only used when hail-aware.
+        real(kind_phys), allocatable :: new_ng_r1(:, :, :)
+        real(kind_phys), allocatable :: new_volg_r1(:, :, :)
+        type(ty_tempo_driver_diags) :: tempo_driver_diags
+
+        errmsg = ''
+        errflg = 0
+
+        rain(:) = 0.0_kind_phys
+        ice(:) = 0.0_kind_phys
+        snow(:) = 0.0_kind_phys
+        graupel(:) = 0.0_kind_phys
+        prcp(:) = 0.0_kind_phys
+
+        tend_th(:, :) = 0.0_kind_phys
+        tend_qv(:, :) = 0.0_kind_phys
+        tend_qc(:, :) = 0.0_kind_phys
+        tend_qr(:, :) = 0.0_kind_phys
+        tend_qi(:, :) = 0.0_kind_phys
+        tend_qs(:, :) = 0.0_kind_phys
+        tend_qg(:, :) = 0.0_kind_phys
+        tend_nr(:, :) = 0.0_kind_phys
+        tend_ni(:, :) = 0.0_kind_phys
+
+        tend_nc(:, :) = 0.0_kind_phys
+        tend_nwfa(:, :) = 0.0_kind_phys
+        tend_nifa(:, :) = 0.0_kind_phys
+
+        tend_ng(:, :) = 0.0_kind_phys
+        tend_volg(:, :) = 0.0_kind_phys
+
+        dz_r1(:, :, 1) = dz(:, pver:1:-1)
+        w_r1(:, :, 1) = w(:, pver:1:-1)
+        p_r1(:, :, 1) = p(:, pver:1:-1)
+        exner_r1(:, :, 1) = exner(:, pver:1:-1)
+
+        ! Check for existing CCN and IN aerosol data. If missing,
+        ! fill in just a basic vertical profile that is somewhat boundary layer following.
+        if (initial_run .and. tempo_cfgs % aerosolaware_flag) then
+            ! Potential cloud condensation nuclei (CCN).
+            if (maxval(nwfa) < eps) then
+                do i = 1, ncol
+                    call init_water_friendly_aerosols(dz_r1(i, :, 1), nwfa(i, :))
+
+                    nwfa2d(i) = nwfa(i, 1) * 0.000196_kind_phys * (50.0_kind_phys / dz_r1(i, 1, 1))
+                end do
+            else
+                if (maxval(nwfa2d) < eps) then
+                    do i = 1, ncol
+                        nwfa2d(i) = nwfa(i, 1) * 0.000196_kind_phys * (5.0_kind_phys / dz_r1(i, 1, 1))
+                    end do
+                end if
+            end if
+
+            ! Potential ice nuclei (IN).
+            if (maxval(nifa) < eps) then
+                do i = 1, ncol
+                    call init_ice_friendly_aerosols(dz_r1(i, :, 1), nifa(i, :))
+
+                    nifa2d(i) = 0.0_kind_phys
+                end do
+            else
+                if (maxval(nifa2d) < eps) then
+                    nifa2d = 0.0_kind_phys
+                end if
+            end if
+
+            ! Ensure non-negative aerosol number concentrations.
+            where (nwfa <= 0.0_kind_phys)
+                nwfa = 1.1E6_kind_phys
+            end where
+
+            where (nifa <= 0.0_kind_phys)
+                nifa = nain1 * 0.01_kind_phys
+            end where
+
+            ! Flip upside down to be consistent with CAM-SIMA. Index 1 is at the top of atmosphere.
+            nwfa(:, :) = nwfa(:, pver:1:-1)
+            nifa(:, :) = nifa(:, pver:1:-1)
+        end if
+
+        new_th_r1(:, :, 1) = th(:, pver:1:-1)
+        new_qv_r1(:, :, 1) = qv(:, pver:1:-1)
+        new_qc_r1(:, :, 1) = qc(:, pver:1:-1)
+        new_qr_r1(:, :, 1) = qr(:, pver:1:-1)
+        new_qi_r1(:, :, 1) = qi(:, pver:1:-1)
+        new_qs_r1(:, :, 1) = qs(:, pver:1:-1)
+        new_qg_r1(:, :, 1) = qg(:, pver:1:-1)
+        new_nr_r1(:, :, 1) = nr(:, pver:1:-1)
+        new_ni_r1(:, :, 1) = ni(:, pver:1:-1)
+
+        if (tempo_cfgs % aerosolaware_flag) then
+            allocate(nwfa_r1(ncol, pver, 1), nwfa2d_1(ncol, 1), &
+                errmsg=errmsg, stat=errflg)
+
+            if (errflg /= 0) then
+                errmsg = 'mp_tempo_run: Failed to allocate "nwfa_r1", "nwfa2d_1"' // new_line('') // &
+                    trim(adjustl(errmsg))
+
+                return
+            end if
+
+            allocate(new_nc_r1(ncol, pver, 1), new_nwfa_r1(ncol, pver, 1), new_nifa_r1(ncol, pver, 1), &
+                errmsg=errmsg, stat=errflg)
+
+            if (errflg /= 0) then
+                errmsg = 'mp_tempo_run: Failed to allocate "new_nc_r1", "new_nwfa_r1", "new_nifa_r1"' // new_line('') // &
+                    trim(adjustl(errmsg))
+
+                return
+            end if
+
+            new_nc_r1(:, :, 1) = nc(:, pver:1:-1)
+            new_nwfa_r1(:, :, 1) = nwfa(:, pver:1:-1)
+            new_nifa_r1(:, :, 1) = nifa(:, pver:1:-1)
+        end if
+
+        if (tempo_cfgs % hailaware_flag) then
+            allocate(new_ng_r1(ncol, pver, 1), new_volg_r1(ncol, pver, 1), &
+                errmsg=errmsg, stat=errflg)
+
+            if (errflg /= 0) then
+                errmsg = 'mp_tempo_run: Failed to allocate "new_ng_r1", "new_volg_r1"' // new_line('') // &
+                    trim(adjustl(errmsg))
+
+                return
+            end if
+
+            new_ng_r1(:, :, 1) = ng(:, pver:1:-1)
+            new_volg_r1(:, :, 1) = volg(:, pver:1:-1)
+        end if
+
+        ! Set subcycle timestep.
+        dtime_subcyc = dtime_phys / real(num_subcyc, kind_phys)
+
+        ! Set internal dimensions.
+        ids = 1
+        ims = 1
+        its = 1
+        ide = ncol
+        ime = ncol
+        ite = ncol
+        jds = 1
+        jms = 1
+        jts = 1
+        jde = 1
+        jme = 1
+        jte = 1
+        kds = 1
+        kms = 1
+        kts = 1
+        kde = pver
+        kme = pver
+        kte = pver
+
+        do i = 1, num_subcyc
+            if (tempo_cfgs % aerosolaware_flag) then
+                nwfa_r1(:, :, 1) = nwfa(:, pver:1:-1)
+                nwfa2d_1(:, 1) = nwfa2d(:)
+
+                call tempo_aerosol_surface_emissions( &
+                    dt=dtime_subcyc, nwfa=nwfa_r1, nwfa2d=nwfa2d_1, &
+                    ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, kts=kts)
+
+                new_nwfa_r1(:, :, 1) = nwfa_r1(:, :, 1)
+            end if
+
+            call tempo_run( &
+                itimestep=curr_step, dt=dtime_subcyc, &
+                dz=dz_r1, w=w_r1, p=p_r1, pii=exner_r1, th=new_th_r1, &
+                qv=new_qv_r1, qc=new_qc_r1, qr=new_qr_r1, qi=new_qi_r1, qs=new_qs_r1, qg=new_qg_r1, nr=new_nr_r1, ni=new_ni_r1, &
+                nc=new_nc_r1, nwfa=new_nwfa_r1, nifa=new_nifa_r1, &
+                ng=new_ng_r1, qb=new_volg_r1, &
+                ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde, &
+                ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, &
+                its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte, &
+                tempo_cfgs=tempo_cfgs, &
+                tempo_diags=tempo_driver_diags)
+
+            ! TEMPO precipitation output is in mm. Convert to m and accumulate.
+            rain(:) = rain(:) + &
+                max(0.0_kind_phys, tempo_driver_diags % rain_precip(:, 1)) / 1000.0_kind_phys
+            ice(:) = ice(:) + &
+                max(0.0_kind_phys, tempo_driver_diags % ice_liquid_equiv_precip(:, 1)) / 1000.0_kind_phys
+            snow(:) = snow(:) + ( &
+                max(0.0_kind_phys, tempo_driver_diags % ice_liquid_equiv_precip(:, 1)) + &
+                max(0.0_kind_phys, tempo_driver_diags % snow_liquid_equiv_precip(:, 1)) &
+                ) / 1000.0_kind_phys
+            graupel(:) = graupel(:) + &
+                max(0.0_kind_phys, tempo_driver_diags % graupel_liquid_equiv_precip(:, 1)) / 1000.0_kind_phys
+            prcp(:) = prcp(:) + ( &
+                max(0.0_kind_phys, tempo_driver_diags % rain_precip(:, 1)) + &
+                max(0.0_kind_phys, tempo_driver_diags % ice_liquid_equiv_precip(:, 1)) + &
+                max(0.0_kind_phys, tempo_driver_diags % snow_liquid_equiv_precip(:, 1)) + &
+                max(0.0_kind_phys, tempo_driver_diags % graupel_liquid_equiv_precip(:, 1)) &
+                ) / 1000.0_kind_phys
+        end do
+
+        tend_th(:, :) = (new_th_r1(:, pver:1:-1, 1) - th(:, :)) / dtime_phys
+        tend_qv(:, :) = (new_qv_r1(:, pver:1:-1, 1) - qv(:, :)) / dtime_phys
+        tend_qc(:, :) = (new_qc_r1(:, pver:1:-1, 1) - qc(:, :)) / dtime_phys
+        tend_qr(:, :) = (new_qr_r1(:, pver:1:-1, 1) - qr(:, :)) / dtime_phys
+        tend_qi(:, :) = (new_qi_r1(:, pver:1:-1, 1) - qi(:, :)) / dtime_phys
+        tend_qs(:, :) = (new_qs_r1(:, pver:1:-1, 1) - qs(:, :)) / dtime_phys
+        tend_qg(:, :) = (new_qg_r1(:, pver:1:-1, 1) - qg(:, :)) / dtime_phys
+        tend_nr(:, :) = (new_nr_r1(:, pver:1:-1, 1) - nr(:, :)) / dtime_phys
+        tend_ni(:, :) = (new_ni_r1(:, pver:1:-1, 1) - ni(:, :)) / dtime_phys
+
+        if (tempo_cfgs % aerosolaware_flag) then
+            tend_nc(:, :) = (new_nc_r1(:, pver:1:-1, 1) - nc(:, :)) / dtime_phys
+            tend_nwfa(:, :) = (new_nwfa_r1(:, pver:1:-1, 1) - nwfa(:, :)) / dtime_phys
+            tend_nifa(:, :) = (new_nifa_r1(:, pver:1:-1, 1) - nifa(:, :)) / dtime_phys
+
+            deallocate(nwfa_r1)
+            deallocate(nwfa2d_1)
+            deallocate(new_nc_r1)
+            deallocate(new_nwfa_r1)
+            deallocate(new_nifa_r1)
+        end if
+
+        if (tempo_cfgs % hailaware_flag) then
+            tend_ng(:, :) = (new_ng_r1(:, pver:1:-1, 1) - ng(:, :)) / dtime_phys
+            tend_volg(:, :) = (new_volg_r1(:, pver:1:-1, 1) - volg(:, :)) / dtime_phys
+
+            deallocate(new_ng_r1)
+            deallocate(new_volg_r1)
+        end if
+
+        frozen_fraction(:) = tempo_driver_diags % frozen_fraction(:, 1)
+        refl10cm(:, :) = tempo_driver_diags % refl10cm(:, pver:1:-1, 1)
+        ! These are in um, not m.
+        re_cloud(:, :) = tempo_driver_diags % re_cloud(:, pver:1:-1, 1)
+        re_ice(:, :) = tempo_driver_diags % re_ice(:, pver:1:-1, 1)
+        re_snow(:, :) = tempo_driver_diags % re_snow(:, pver:1:-1, 1)
+    end subroutine mp_tempo_run
+end module mp_tempo

--- a/schemes/tempo/mp_tempo.meta
+++ b/schemes/tempo/mp_tempo.meta
@@ -1,0 +1,458 @@
+[ccpp-table-properties]
+  name = mp_tempo
+  type = scheme
+  dependencies = machine.F90
+  dependencies = module_mp_tempo_cfgs.F90
+  dependencies = tempo/src/module_mp_tempo_aerosols.F90
+  dependencies = tempo/src/module_mp_tempo_diags.F90
+  dependencies = tempo/src/module_mp_tempo_driver.F90
+  dependencies = tempo/src/module_mp_tempo_main.F90
+  dependencies = tempo/src/module_mp_tempo_ml.F90
+  dependencies = tempo/src/module_mp_tempo_params.F90
+  dependencies = tempo/src/module_mp_tempo_utils.F90
+
+[ccpp-arg-table]
+  name = mp_tempo_init
+  type = scheme
+[ num_subcyc ]
+  standard_name = number_of_timestep_subcycles_for_tempo_microphysics
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
+[ aerosol_aware ]
+  standard_name = do_aerosol_aware_microphysics
+  units = flag
+  type = logical
+  dimensions = ()
+  intent = in
+[ hail_aware ]
+  standard_name = do_hail_aware_microphysics
+  units = flag
+  type = logical
+  dimensions = ()
+  intent = in
+[ refl_incl_melt ]
+  standard_name = do_radar_reflectivity_with_melting_hydrometeors
+  units = flag
+  type = logical
+  dimensions = ()
+  intent = in
+[ sat_adj ]
+  standard_name = do_saturation_adjustment
+  units = flag
+  type = logical
+  dimensions = ()
+  intent = in
+[ semi_lagr_sedi ]
+  standard_name = do_semi_lagrangian_sedimentation_of_hydrometeors
+  units = flag
+  type = logical
+  dimensions = ()
+  intent = in
+[ con_pi ]
+  standard_name = pi_constant
+  units = 1
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ con_hvap ]
+  standard_name = latent_heat_of_vaporization_of_water_at_0C
+  units = J kg-1
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ con_hfus ]
+  standard_name = latent_heat_of_fusion_of_water_at_0C
+  units = J kg-1
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ con_rv ]
+  standard_name = gas_constant_of_water_vapor
+  units = J kg-1 K-1
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ con_rd ]
+  standard_name = gas_constant_of_dry_air
+  units = J kg-1 K-1
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ con_cp ]
+  standard_name = specific_heat_of_dry_air_at_constant_pressure
+  units = J kg-1 K-1
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ con_t0c ]
+  standard_name = freezing_point_of_water
+  units = K
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ con_rgas ]
+  standard_name = universal_gas_constant
+  units = J K-1 kmol-1
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ con_rhow ]
+  standard_name = fresh_liquid_water_density_at_0c
+  units = kg m-3
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ tempo_cfgs ]
+  standard_name = configuration_for_tempo_microphysics
+  units = mixed
+  type = ty_tempo_cfgs
+  dimensions = ()
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  type = character | kind = len=*
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+
+[ccpp-arg-table]
+  name = mp_tempo_run
+  type = scheme
+[ ncol ]
+  standard_name = horizontal_loop_extent
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
+[ pver ]
+  standard_name = vertical_layer_dimension
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
+[ curr_step ]
+  standard_name = current_timestep_number
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
+[ num_subcyc ]
+  standard_name = number_of_timestep_subcycles_for_tempo_microphysics
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
+[ initial_run ]
+  standard_name = is_initial_run
+  units = flag
+  type = logical
+  dimensions = ()
+  intent = in
+[ dtime_phys ]
+  standard_name = timestep_for_physics
+  units = s
+  type = real | kind = kind_phys
+  dimensions = ()
+  intent = in
+[ dz ]
+  standard_name = atmosphere_layer_thickness
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ w ]
+  standard_name = upward_air_velocity
+  units = m s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ p ]
+  standard_name = air_pressure
+  units = Pa
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ exner ]
+  standard_name = dimensionless_exner_function
+  units = 1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ th ]
+  standard_name = air_potential_temperature
+  units = K
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qv ]
+  standard_name = water_vapor_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qc ]
+  standard_name = cloud_liquid_water_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qr ]
+  standard_name = rain_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qi ]
+  standard_name = cloud_ice_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qs ]
+  standard_name = snow_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qg ]
+  standard_name = graupel_mixing_ratio_wrt_dry_air
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ nr ]
+  standard_name = mass_number_concentration_of_rain_in_dry_air
+  units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+  advected = True
+[ ni ]
+  standard_name = mass_number_concentration_of_cloud_ice_water_crystals_in_dry_air
+  units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+  advected = True
+[ nc ]
+  standard_name = mass_number_concentration_of_cloud_liquid_water_droplets_in_dry_air
+  units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+  advected = True
+[ nwfa ]
+  standard_name = mass_number_concentration_of_hygroscopic_aerosols_in_dry_air
+  units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+  advected = True
+[ nifa ]
+  standard_name = mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_dry_air
+  units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = inout
+  advected = True
+[ nwfa2d ]
+  standard_name = tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = inout
+[ nifa2d ]
+  standard_name = tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = inout
+[ ng ]
+  standard_name = mass_number_concentration_of_graupel_in_dry_air
+  units = kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+  advected = True
+[ volg ]
+  standard_name = graupel_volume_in_dry_air
+  units = m3 kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+  advected = True
+[ tempo_cfgs ]
+  standard_name = configuration_for_tempo_microphysics
+  units = mixed
+  type = ty_tempo_cfgs
+  dimensions = ()
+  intent = in
+[ rain ]
+  standard_name = lwe_thickness_of_rainfall_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = out
+[ ice ]
+  standard_name = lwe_thickness_of_ice_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = out
+[ snow ]
+  standard_name = lwe_thickness_of_snowfall_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = out
+[ graupel ]
+  standard_name = lwe_thickness_of_graupel_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = out
+[ prcp ]
+  standard_name = lwe_thickness_of_precipitation_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = out
+[ tend_th ]
+  standard_name = tendency_of_air_potential_temperature_due_to_microphysics
+  units = K s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_qv ]
+  standard_name = tendency_of_water_vapor_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_qc ]
+  standard_name = tendency_of_cloud_liquid_water_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_qr ]
+  standard_name = tendency_of_rain_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_qi ]
+  standard_name = tendency_of_cloud_ice_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_qs ]
+  standard_name = tendency_of_snow_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_qg ]
+  standard_name = tendency_of_graupel_mixing_ratio_wrt_dry_air_due_to_microphysics
+  units = kg kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_nr ]
+  standard_name = tendency_of_mass_number_concentration_of_rain_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_ni ]
+  standard_name = tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ frozen_fraction ]
+  standard_name = ratio_of_snowfall_to_rainfall
+  units = fraction
+  type = real
+  kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = out
+[ refl10cm ]
+  standard_name = radar_reflectivity_at_10cm_wavelength
+  units = dBZ
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ re_cloud ]
+  standard_name = effective_radius_of_stratiform_cloud_liquid_water_particle
+  units = um
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ re_ice ]
+  standard_name = effective_radius_of_stratiform_cloud_ice_particle
+  units = um
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ re_snow ]
+  standard_name = effective_radius_of_stratiform_cloud_snow_particle
+  units = um
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_nc ]
+  standard_name = tendency_of_mass_number_concentration_of_cloud_liquid_water_droplets_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_nwfa ]
+  standard_name = tendency_of_mass_number_concentration_of_hygroscopic_aerosols_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_nifa ]
+  standard_name = tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_ng ]
+  standard_name = tendency_of_mass_number_concentration_of_graupel_in_dry_air_due_to_microphysics
+  units = kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ tend_volg ]
+  standard_name = tendency_of_graupel_volume_in_dry_air_due_to_microphysics
+  units = m3 kg-1 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  type = character | kind = len=*
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/tempo/mp_tempo_diag.F90
+++ b/schemes/tempo/mp_tempo_diag.F90
@@ -1,0 +1,93 @@
+module mp_tempo_diag
+    implicit none
+
+    private
+    public :: mp_tempo_diagnostics_init
+    public :: mp_tempo_diagnostics_run
+contains
+    !> \section arg_table_mp_tempo_diagnostics_init Argument Table
+    !! \htmlinclude mp_tempo_diagnostics_init.html
+    subroutine mp_tempo_diagnostics_init( &
+            errmsg, errflg)
+        use cam_history, only: history_add_field
+        use cam_history_support, only: horiz_only
+
+        character(*), intent(out) :: errmsg
+        integer, intent(out) :: errflg
+
+        call history_add_field( &
+            'mp_tempo_rain', &
+            'lwe_thickness_of_rainfall_amount', &
+            horiz_only, 'avg', 'm')
+        call history_add_field( &
+            'mp_tempo_ice', &
+            'lwe_thickness_of_ice_amount', &
+            horiz_only, 'avg', 'm')
+        call history_add_field( &
+            'mp_tempo_snow', &
+            'lwe_thickness_of_snowfall_amount', &
+            horiz_only, 'avg', 'm')
+        call history_add_field( &
+            'mp_tempo_graupel', &
+            'lwe_thickness_of_graupel_amount', &
+            horiz_only, 'avg', 'm')
+        call history_add_field( &
+            'mp_tempo_prcp', &
+            'lwe_thickness_of_precipitation_amount', &
+            horiz_only, 'avg', 'm')
+        call history_add_field( &
+            'mp_tempo_frozen_fraction', &
+            'ratio_of_snowfall_to_rainfall', &
+            horiz_only, 'avg', 'fraction')
+
+        call history_add_field( &
+            'mp_tempo_refl10cm', &
+            'radar_reflectivity_at_10cm_wavelength', &
+            'lev', 'avg', 'dBZ')
+        call history_add_field( &
+            'mp_tempo_re_cloud', &
+            'effective_radius_of_stratiform_cloud_liquid_water_particle', &
+            'lev', 'avg', 'um')
+        call history_add_field( &
+            'mp_tempo_re_ice', &
+            'effective_radius_of_stratiform_cloud_ice_particle', &
+            'lev', 'avg', 'um')
+        call history_add_field( &
+            'mp_tempo_re_snow', &
+            'effective_radius_of_stratiform_cloud_snow_particle', &
+            'lev', 'avg', 'um')
+
+        errmsg = ''
+        errflg = 0
+    end subroutine mp_tempo_diagnostics_init
+
+    !> \section arg_table_mp_tempo_diagnostics_run Argument Table
+    !! \htmlinclude mp_tempo_diagnostics_run.html
+    subroutine mp_tempo_diagnostics_run( &
+            rain, ice, snow, graupel, prcp, &
+            frozen_fraction, refl10cm, re_cloud, re_ice, re_snow, &
+            errmsg, errflg)
+        use cam_history, only: history_out_field
+        use ccpp_kinds, only: kind_phys
+
+        real(kind_phys), intent(in) :: rain(:), ice(:), snow(:), graupel(:), prcp(:), frozen_fraction(:), &
+                                       refl10cm(:, :), re_cloud(:, :), re_ice(:, :), re_snow(:, :)
+        character(*), intent(out) :: errmsg
+        integer, intent(out) :: errflg
+
+        call history_out_field('mp_tempo_rain', rain)
+        call history_out_field('mp_tempo_ice', ice)
+        call history_out_field('mp_tempo_snow', snow)
+        call history_out_field('mp_tempo_graupel', graupel)
+        call history_out_field('mp_tempo_prcp', prcp)
+        call history_out_field('mp_tempo_frozen_fraction', frozen_fraction)
+
+        call history_out_field('mp_tempo_refl10cm', refl10cm)
+        call history_out_field('mp_tempo_re_cloud', re_cloud)
+        call history_out_field('mp_tempo_re_ice', re_ice)
+        call history_out_field('mp_tempo_re_snow', re_snow)
+
+        errmsg = ''
+        errflg = 0
+    end subroutine mp_tempo_diagnostics_run
+end module mp_tempo_diag

--- a/schemes/tempo/mp_tempo_diag.meta
+++ b/schemes/tempo/mp_tempo_diag.meta
@@ -1,0 +1,100 @@
+[ccpp-table-properties]
+  name = mp_tempo_diagnostics
+  type = scheme
+
+[ccpp-arg-table]
+  name = mp_tempo_diagnostics_init
+  type = scheme
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  type = character | kind = len=*
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out
+
+[ccpp-arg-table]
+  name = mp_tempo_diagnostics_run
+  type = scheme
+[ rain ]
+  standard_name = lwe_thickness_of_rainfall_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ ice ]
+  standard_name = lwe_thickness_of_ice_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ snow ]
+  standard_name = lwe_thickness_of_snowfall_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ graupel ]
+  standard_name = lwe_thickness_of_graupel_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ prcp ]
+  standard_name = lwe_thickness_of_precipitation_amount
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ frozen_fraction ]
+  standard_name = ratio_of_snowfall_to_rainfall
+  units = fraction
+  type = real
+  kind = kind_phys
+  dimensions = (horizontal_loop_extent)
+  intent = in
+[ refl10cm ]
+  standard_name = radar_reflectivity_at_10cm_wavelength
+  units = dBZ
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ re_cloud ]
+  standard_name = effective_radius_of_stratiform_cloud_liquid_water_particle
+  units = um
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ re_ice ]
+  standard_name = effective_radius_of_stratiform_cloud_ice_particle
+  units = um
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ re_snow ]
+  standard_name = effective_radius_of_stratiform_cloud_snow_particle
+  units = um
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  type = character | kind = len=*
+  dimensions = ()
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  type = integer
+  dimensions = ()
+  intent = out

--- a/schemes/tempo/mp_tempo_namelist.xml
+++ b/schemes/tempo/mp_tempo_namelist.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+
+<entry_id_pg version="2.0">
+  <entry id="num_subcyc">
+    <type>integer</type>
+    <category>mp_tempo</category>
+    <group>mp_tempo_nl</group>
+    <standard_name>number_of_timestep_subcycles_for_tempo_microphysics</standard_name>
+    <units>count</units>
+    <desc>
+      Number of timestep subcycles for TEMPO microphysics.
+    </desc>
+    <values>
+      <value>1</value>
+    </values>
+  </entry>
+  <entry id="aerosol_aware">
+    <type>logical</type>
+    <category>mp_tempo</category>
+    <group>mp_tempo_nl</group>
+    <standard_name>do_aerosol_aware_microphysics</standard_name>
+    <units>flag</units>
+    <desc>
+       Flag to run aerosol-aware microphysics, with prognostic aerosol number and cloud droplet concentrations.
+    </desc>
+    <values>
+      <value>.true.</value>
+    </values>
+  </entry>
+  <entry id="hail_aware">
+    <type>logical</type>
+    <category>mp_tempo</category>
+    <group>mp_tempo_nl</group>
+    <standard_name>do_hail_aware_microphysics</standard_name>
+    <units>flag</units>
+    <desc>
+       Flag to run hail-aware microphysics, with prognostic graupel number concentration and rime density.
+    </desc>
+    <values>
+      <value>.true.</value>
+    </values>
+  </entry>
+  <entry id="refl_incl_melt">
+    <type>logical</type>
+    <category>mp_tempo</category>
+    <group>mp_tempo_nl</group>
+    <standard_name>do_radar_reflectivity_with_melting_hydrometeors</standard_name>
+    <units>flag</units>
+    <desc>
+       Flag to include contributions from melting hydrometeors (e.g., snow and graupel) in radar reflectivity.
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+  <entry id="sat_adj">
+    <type>logical</type>
+    <category>mp_tempo</category>
+    <group>mp_tempo_nl</group>
+    <standard_name>do_saturation_adjustment</standard_name>
+    <units>flag</units>
+    <desc>
+       Flag to run saturation adjustment. sat_adj=.true. should only be run with aerosol_aware=.false. and hail_aware=.false.
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+  <entry id="semi_lagr_sedi">
+    <type>logical</type>
+    <category>mp_tempo</category>
+    <group>mp_tempo_nl</group>
+    <standard_name>do_semi_lagrangian_sedimentation_of_hydrometeors</standard_name>
+    <units>flag</units>
+    <desc>
+       Flag to run semi-Lagrangian sedimentation of hydrometeors (e.g., rain and graupel).
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+</entry_id_pg>

--- a/schemes/utilities/state_converters.F90
+++ b/schemes/utilities/state_converters.F90
@@ -32,11 +32,13 @@ module state_converters
   public :: wet_to_dry_cloud_ice_run
   public :: wet_to_dry_rain_run
   public :: wet_to_dry_snow_run
+  public :: wet_to_dry_graupel_run
   public :: dry_to_wet_water_vapor_run
   public :: dry_to_wet_cloud_liquid_water_run
   public :: dry_to_wet_cloud_ice_run
   public :: dry_to_wet_rain_run
   public :: dry_to_wet_snow_run
+  public :: dry_to_wet_graupel_run
 
 CONTAINS
 
@@ -337,6 +339,29 @@ CONTAINS
     end do
   end subroutine wet_to_dry_snow_run
 
+  !> \section arg_table_wet_to_dry_graupel_run Argument Table
+  !! \htmlinclude wet_to_dry_graupel_run.html
+  pure subroutine wet_to_dry_graupel_run(ncol, nz, pdel, pdeldry, &
+      qg, qg_dry, errmsg, errflg)
+    integer,          intent(in)  :: ncol
+    integer,          intent(in)  :: nz
+    real(kind_phys),  intent(in)  :: pdel(:, :)    ! pressure thickness of layer (Pa)
+    real(kind_phys),  intent(in)  :: pdeldry(:, :) ! dry air pressure thickness of layer (Pa)
+    real(kind_phys),  intent(in)  :: qg(:, :)      ! graupel mixing ratio wrt moist air (kg/kg)
+    real(kind_phys),  intent(out) :: qg_dry(:, :)  ! graupel mixing ratio wrt dry air (kg/kg)
+    character(len=*), intent(out) :: errmsg
+    integer,          intent(out) :: errflg
+
+    integer :: k
+
+    errflg = 0
+    errmsg = ''
+
+    do k = 1, nz
+      qg_dry(:ncol, k) = qg(:ncol, k) * (pdel(:ncol, k) / pdeldry(:ncol, k))
+    end do
+  end subroutine wet_to_dry_graupel_run
+
 !> \section arg_table_dry_to_wet_water_vapor_run  Argument Table
 !! \htmlinclude dry_to_wet_water_vapor_run.html
   subroutine dry_to_wet_water_vapor_run(ncol, nz, pdel, pdeldry, qv_dry, qv,  &
@@ -459,4 +484,27 @@ CONTAINS
       qs(:ncol, k) = qs_dry(:ncol, k) * (pdeldry(:ncol, k) / pdel(:ncol, k))
     end do
   end subroutine dry_to_wet_snow_run
+
+  !> \section arg_table_dry_to_wet_graupel_run Argument Table
+  !! \htmlinclude dry_to_wet_graupel_run.html
+  pure subroutine dry_to_wet_graupel_run(ncol, nz, pdel, pdeldry, &
+      qg_dry, qg, errmsg, errflg)
+    integer,          intent(in)  :: ncol
+    integer,          intent(in)  :: nz
+    real(kind_phys),  intent(in)  :: pdel(:, :)    ! pressure thickness of layer (Pa)
+    real(kind_phys),  intent(in)  :: pdeldry(:, :) ! dry air pressure thickness of layer (Pa)
+    real(kind_phys),  intent(in)  :: qg_dry(:, :)  ! graupel mixing ratio wrt dry air (kg/kg)
+    real(kind_phys),  intent(out) :: qg(:, :)      ! graupel mixing ratio wrt moist air (kg/kg)
+    character(len=*), intent(out) :: errmsg
+    integer,          intent(out) :: errflg
+
+    integer :: k
+
+    errflg = 0
+    errmsg = ''
+
+    do k = 1, nz
+      qg(:ncol, k) = qg_dry(:ncol, k) * (pdeldry(:ncol, k) / pdel(:ncol, k))
+    end do
+  end subroutine dry_to_wet_graupel_run
 end module state_converters

--- a/schemes/utilities/state_converters.meta
+++ b/schemes/utilities/state_converters.meta
@@ -733,6 +733,68 @@
 
 #########################################################
 [ccpp-table-properties]
+  name = wet_to_dry_graupel
+  type = scheme
+[ccpp-arg-table]
+  name = wet_to_dry_graupel_run
+  type = scheme
+[ ncol ]
+  standard_name = horizontal_loop_extent
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+[ nz ]
+  standard_name = vertical_layer_dimension
+  long_name = number of vertical layers
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+[ pdel ]
+  standard_name = air_pressure_thickness
+  type = real | kind = kind_phys
+  units = Pa
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ pdeldry ]
+  standard_name = air_pressure_thickness_of_dry_air
+  type = real | kind = kind_phys
+  units = Pa
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qg ]
+  standard_name = graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water
+  long_name = Mass mixing ratio of graupel / moist air + condensed water
+  advected = True
+  type = real | kind = kind_phys
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qg_dry ]
+  standard_name = graupel_mixing_ratio_wrt_dry_air
+  long_name = Mass mixing ratio of graupel / dry air
+  type = real | kind = kind_phys
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character | kind = len=*
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+
+#########################################################
+[ccpp-table-properties]
   name = dry_to_wet_water_vapor
   type = scheme
 [ccpp-arg-table]
@@ -1020,6 +1082,68 @@
 [ qs ]
   standard_name = snow_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = Mass mixing ratio of snow / moist_air
+  advected = True
+  type = real | kind = kind_phys
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = out
+[ errmsg ]
+  standard_name = ccpp_error_message
+  long_name = Error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character | kind = len=*
+  intent = out
+[ errflg ]
+  standard_name = ccpp_error_code
+  long_name = Error flag for error handling in CCPP
+  units = 1
+  dimensions = ()
+  type = integer
+  intent = out
+
+#########################################################
+[ccpp-table-properties]
+  name = dry_to_wet_graupel
+  type = scheme
+[ccpp-arg-table]
+  name = dry_to_wet_graupel_run
+  type = scheme
+[ ncol ]
+  standard_name = horizontal_loop_extent
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+[ nz ]
+  standard_name = vertical_layer_dimension
+  long_name = number of vertical layers
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+[ pdel ]
+  standard_name = air_pressure_thickness
+  type = real | kind = kind_phys
+  units = Pa
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ pdeldry ]
+  standard_name = air_pressure_thickness_of_dry_air
+  type = real | kind = kind_phys
+  units = Pa
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qg_dry ]
+  standard_name = graupel_mixing_ratio_wrt_dry_air
+  long_name = Mass mixing ratio of graupel / dry air
+  type = real | kind = kind_phys
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ qg ]
+  standard_name = graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water
+  long_name = Mass mixing ratio of graupel / moist air + condensed water
   advected = True
   type = real | kind = kind_phys
   units = kg kg-1

--- a/test/test_suites/suite_convection_permitting.xml
+++ b/test/test_suites/suite_convection_permitting.xml
@@ -5,6 +5,12 @@
     <!-- Prepare input needed by the suite -->
     <scheme>prescribe_radiative_gas_concentrations</scheme>
     <scheme>to_be_ccppized_temporary</scheme>
+
+    <scheme>prescribed_aerosols</scheme>
+    <scheme>prescribed_aerosol_deposition_flux</scheme>
+    <scheme>tropopause_find</scheme>
+    <scheme>prescribed_volcanic_aerosol</scheme>
+
     <scheme>calc_atmosphere_layer_thickness</scheme>
     <scheme>calc_exner</scheme>
     <scheme>temp_to_potential_temp</scheme>
@@ -17,13 +23,27 @@
     <scheme>geopotential_height_wrt_sfc_at_interface_to_msl</scheme>
     <scheme>wet_to_dry_water_vapor</scheme>
     <scheme>wet_to_dry_cloud_liquid_water</scheme>
+    <scheme>wet_to_dry_rain</scheme>
     <scheme>wet_to_dry_cloud_ice</scheme>
     <scheme>wet_to_dry_snow</scheme>
+    <scheme>wet_to_dry_graupel</scheme>
 
     <scheme>mmm_physics_compat</scheme>
 
+    <!-- TEMPO Microphysics -->
+    <scheme>mp_tempo</scheme>
+    <scheme>mp_tempo_diagnostics</scheme>
+
+    <!-- Xu-Randall cloud fraction -->
+    <scheme>cldfra_xu_randall</scheme>
+    <scheme>cldfra_xu_randall_diagnostics</scheme>
+
     <!-- Begin section RRTMGP radiation scheme -->
     <scheme>rrtmgp_pre</scheme>
+
+    <scheme>aerosol_optics</scheme>
+    <scheme>aerosol_optics_diagnostics</scheme>
+
     <scheme>rrtmgp_cloud_optics_setup</scheme>
     <scheme>tropopause_find</scheme>
     <scheme>rrtmgp_variables</scheme>
@@ -102,8 +122,10 @@
     <scheme>apply_tendency_of_air_temperature</scheme>
     <scheme>dry_to_wet_water_vapor</scheme>
     <scheme>dry_to_wet_cloud_liquid_water</scheme>
+    <scheme>dry_to_wet_rain</scheme>
     <scheme>dry_to_wet_cloud_ice</scheme>
     <scheme>dry_to_wet_snow</scheme>
+    <scheme>dry_to_wet_graupel</scheme>
     <scheme>qneg</scheme>
     <scheme>geopotential_temp</scheme>
 

--- a/test/unit-test/tests/mmm/mmm_physics_compat_tests.pf
+++ b/test/unit-test/tests/mmm/mmm_physics_compat_tests.pf
@@ -173,13 +173,17 @@ subroutine test_mmm_physics_accumulate_tendencies_timestep_init()
     integer, parameter :: ncol = 100, pver = 10
     real(kind_phys) :: dudt(ncol, pver), dvdt(ncol, pver), dtdt(ncol, pver)
     real(kind_phys) :: rublten(ncol, pver), rucuten(ncol, pver), rvblten(ncol, pver), rvcuten(ncol, pver)
-    real(kind_phys) :: rthblten(ncol, pver), rthcuten(ncol, pver), rthratenlw(ncol, pver), rthratensw(ncol, pver)
-    real(kind_phys) :: rqvblten(ncol, pver), rqvcuten(ncol, pver)
-    real(kind_phys) :: rqcblten(ncol, pver), rncblten(ncol, pver), rqccuten(ncol, pver)
-    real(kind_phys) :: rqiblten(ncol, pver), rniblten(ncol, pver), rqicuten(ncol, pver)
-    real(kind_phys) :: rqsblten(ncol, pver)
+    real(kind_phys) :: rthblten(ncol, pver), rthcuten(ncol, pver), rthmpten(ncol, pver), &
+                       rthratenlw(ncol, pver), rthratensw(ncol, pver)
+    real(kind_phys) :: rqvblten(ncol, pver), rqvcuten(ncol, pver), rqvmpten(ncol, pver)
+    real(kind_phys) :: rqcblten(ncol, pver), rncblten(ncol, pver), rqccuten(ncol, pver), rqcmpten(ncol, pver), rncmpten(ncol, pver)
+    real(kind_phys) :: rqrmpten(ncol, pver), rnrmpten(ncol, pver)
+    real(kind_phys) :: rqiblten(ncol, pver), rniblten(ncol, pver), rqicuten(ncol, pver), rqimpten(ncol, pver), rnimpten(ncol, pver)
+    real(kind_phys) :: rqsblten(ncol, pver), rqsmpten(ncol, pver)
+    real(kind_phys) :: rqgmpten(ncol, pver), rngmpten(ncol, pver), rvolgmpten(ncol, pver)
     real(kind_phys) :: rozblten(ncol, pver)
-    real(kind_phys) :: rnwfablten(ncol, pver), rnifablten(ncol, pver), rnbcablten(ncol, pver)
+    real(kind_phys) :: rnwfablten(ncol, pver), rnwfampten(ncol, pver), rnifablten(ncol, pver), rnifampten(ncol, pver), &
+                       rnbcablten(ncol, pver)
     character(100) :: errmsg
     integer :: errflg
 
@@ -194,38 +198,56 @@ subroutine test_mmm_physics_accumulate_tendencies_timestep_init()
 
     rthblten(:, :) = huge(0.0_kind_phys)
     rthcuten(:, :) = huge(0.0_kind_phys)
+    rthmpten(:, :) = huge(0.0_kind_phys)
     rthratenlw(:, :) = huge(0.0_kind_phys)
     rthratensw(:, :) = huge(0.0_kind_phys)
 
     rqvblten(:, :) = huge(0.0_kind_phys)
     rqvcuten(:, :) = huge(0.0_kind_phys)
+    rqvmpten(:, :) = huge(0.0_kind_phys)
 
     rqcblten(:, :) = huge(0.0_kind_phys)
     rncblten(:, :) = huge(0.0_kind_phys)
     rqccuten(:, :) = huge(0.0_kind_phys)
+    rqcmpten(:, :) = huge(0.0_kind_phys)
+    rncmpten(:, :) = huge(0.0_kind_phys)
+
+    rqrmpten(:, :) = huge(0.0_kind_phys)
+    rnrmpten(:, :) = huge(0.0_kind_phys)
 
     rqiblten(:, :) = huge(0.0_kind_phys)
     rniblten(:, :) = huge(0.0_kind_phys)
     rqicuten(:, :) = huge(0.0_kind_phys)
+    rqimpten(:, :) = huge(0.0_kind_phys)
+    rnimpten(:, :) = huge(0.0_kind_phys)
 
     rqsblten(:, :) = huge(0.0_kind_phys)
+    rqsmpten(:, :) = huge(0.0_kind_phys)
+
+    rqgmpten(:, :) = huge(0.0_kind_phys)
+    rngmpten(:, :) = huge(0.0_kind_phys)
+    rvolgmpten(:, :) = huge(0.0_kind_phys)
 
     rozblten(:, :) = huge(0.0_kind_phys)
 
     rnwfablten(:, :) = huge(0.0_kind_phys)
+    rnwfampten(:, :) = huge(0.0_kind_phys)
     rnifablten(:, :) = huge(0.0_kind_phys)
+    rnifampten(:, :) = huge(0.0_kind_phys)
     rnbcablten(:, :) = huge(0.0_kind_phys)
 
     call mmm_physics_accumulate_tendencies_timestep_init( &
         dudt, dvdt, dtdt, &
         rublten, rucuten, rvblten, rvcuten, &
-        rthblten, rthcuten, rthratenlw, rthratensw, &
-        rqvblten, rqvcuten, &
-        rqcblten, rncblten, rqccuten, &
-        rqiblten, rniblten, rqicuten, &
-        rqsblten, &
+        rthblten, rthcuten, rthmpten, rthratenlw, rthratensw, &
+        rqvblten, rqvcuten, rqvmpten, &
+        rqcblten, rncblten, rqccuten, rqcmpten, rncmpten, &
+        rqrmpten, rnrmpten, &
+        rqiblten, rniblten, rqicuten, rqimpten, rnimpten, &
+        rqsblten, rqsmpten, &
+        rqgmpten, rngmpten, rvolgmpten, &
         rozblten, &
-        rnwfablten, rnifablten, rnbcablten, &
+        rnwfablten, rnwfampten, rnifablten, rnifampten, rnbcablten, &
         errmsg, errflg)
 
     ! Everything should be zeroed out.
@@ -240,26 +262,42 @@ subroutine test_mmm_physics_accumulate_tendencies_timestep_init()
 
     @assertEqual(0.0_kind_phys, rthblten)
     @assertEqual(0.0_kind_phys, rthcuten)
+    @assertEqual(0.0_kind_phys, rthmpten)
     @assertEqual(0.0_kind_phys, rthratenlw)
     @assertEqual(0.0_kind_phys, rthratensw)
 
     @assertEqual(0.0_kind_phys, rqvblten)
     @assertEqual(0.0_kind_phys, rqvcuten)
+    @assertEqual(0.0_kind_phys, rqvmpten)
 
     @assertEqual(0.0_kind_phys, rqcblten)
     @assertEqual(0.0_kind_phys, rncblten)
     @assertEqual(0.0_kind_phys, rqccuten)
+    @assertEqual(0.0_kind_phys, rqcmpten)
+    @assertEqual(0.0_kind_phys, rncmpten)
+
+    @assertEqual(0.0_kind_phys, rqrmpten)
+    @assertEqual(0.0_kind_phys, rnrmpten)
 
     @assertEqual(0.0_kind_phys, rqiblten)
     @assertEqual(0.0_kind_phys, rniblten)
     @assertEqual(0.0_kind_phys, rqicuten)
+    @assertEqual(0.0_kind_phys, rqimpten)
+    @assertEqual(0.0_kind_phys, rnimpten)
 
     @assertEqual(0.0_kind_phys, rqsblten)
+    @assertEqual(0.0_kind_phys, rqsmpten)
+
+    @assertEqual(0.0_kind_phys, rqgmpten)
+    @assertEqual(0.0_kind_phys, rngmpten)
+    @assertEqual(0.0_kind_phys, rvolgmpten)
 
     @assertEqual(0.0_kind_phys, rozblten)
 
     @assertEqual(0.0_kind_phys, rnwfablten)
+    @assertEqual(0.0_kind_phys, rnwfampten)
     @assertEqual(0.0_kind_phys, rnifablten)
+    @assertEqual(0.0_kind_phys, rnifampten)
     @assertEqual(0.0_kind_phys, rnbcablten)
 
     @assertEqual('', errmsg)
@@ -275,16 +313,23 @@ subroutine test_mmm_physics_accumulate_tendencies_run()
     integer, parameter :: ncol = 100, pver = 10
     real(kind_phys) :: dt, exner(ncol, pver)
     real(kind_phys) :: dudt(ncol, pver), dvdt(ncol, pver), dtdt(ncol, pver)
-    real(kind_phys) :: theta(ncol, pver), qv(ncol, pver), qc(ncol, pver), qi(ncol, pver), qs(ncol, pver), ozone(ncol, pver)
-    real(kind_phys) :: nc(ncol, pver), ni(ncol, pver), nwfa(ncol, pver), nifa(ncol, pver), nbca(ncol, pver)
+    real(kind_phys) :: theta(ncol, pver), qv(ncol, pver), qc(ncol, pver), qr(ncol, pver), &
+                       qi(ncol, pver), qs(ncol, pver), qg(ncol, pver), ozone(ncol, pver)
+    real(kind_phys) :: nc(ncol, pver), nr(ncol, pver), ni(ncol, pver), ng(ncol, pver), &
+                       nwfa(ncol, pver), nifa(ncol, pver), nbca(ncol, pver)
+    real(kind_phys) :: volg(ncol, pver)
     real(kind_phys) :: rublten(ncol, pver), rucuten(ncol, pver), rvblten(ncol, pver), rvcuten(ncol, pver)
-    real(kind_phys) :: rthblten(ncol, pver), rthcuten(ncol, pver), rthratenlw(ncol, pver), rthratensw(ncol, pver)
-    real(kind_phys) :: rqvblten(ncol, pver), rqvcuten(ncol, pver)
-    real(kind_phys) :: rqcblten(ncol, pver), rncblten(ncol, pver), rqccuten(ncol, pver)
-    real(kind_phys) :: rqiblten(ncol, pver), rniblten(ncol, pver), rqicuten(ncol, pver)
-    real(kind_phys) :: rqsblten(ncol, pver)
+    real(kind_phys) :: rthblten(ncol, pver), rthcuten(ncol, pver), rthmpten(ncol, pver), &
+                       rthratenlw(ncol, pver), rthratensw(ncol, pver)
+    real(kind_phys) :: rqvblten(ncol, pver), rqvcuten(ncol, pver), rqvmpten(ncol, pver)
+    real(kind_phys) :: rqcblten(ncol, pver), rncblten(ncol, pver), rqccuten(ncol, pver), rqcmpten(ncol, pver), rncmpten(ncol, pver)
+    real(kind_phys) :: rqrmpten(ncol, pver), rnrmpten(ncol, pver)
+    real(kind_phys) :: rqiblten(ncol, pver), rniblten(ncol, pver), rqicuten(ncol, pver), rqimpten(ncol, pver), rnimpten(ncol, pver)
+    real(kind_phys) :: rqsblten(ncol, pver), rqsmpten(ncol, pver)
+    real(kind_phys) :: rqgmpten(ncol, pver), rngmpten(ncol, pver), rvolgmpten(ncol, pver)
     real(kind_phys) :: rozblten(ncol, pver)
-    real(kind_phys) :: rnwfablten(ncol, pver), rnifablten(ncol, pver), rnbcablten(ncol, pver)
+    real(kind_phys) :: rnwfablten(ncol, pver), rnwfampten(ncol, pver), rnifablten(ncol, pver), rnifampten(ncol, pver), &
+                       rnbcablten(ncol, pver)
     character(100) :: errmsg
     integer :: errflg
 
@@ -298,15 +343,21 @@ subroutine test_mmm_physics_accumulate_tendencies_run()
     theta(:, :) = 273.15_kind_phys
     qv(:, :) = 0.01_kind_phys
     qc(:, :) = 0.01_kind_phys
+    qr(:, :) = 0.01_kind_phys
     qi(:, :) = 0.01_kind_phys
     qs(:, :) = 0.01_kind_phys
+    qg(:, :) = 0.01_kind_phys
     ozone(:, :) = 1.0E-8_kind_phys
 
     nc(:, :) = 1.0E8_kind_phys
+    nr(:, :) = 1.0E8_kind_phys
     ni(:, :) = 1.0E6_kind_phys
+    ng(:, :) = 1.0E6_kind_phys
     nwfa(:, :) = 1.0E8_kind_phys
     nifa(:, :) = 1.0E8_kind_phys
     nbca(:, :) = 1.0E8_kind_phys
+
+    volg(:, :) = 0.01_kind_phys
 
     rublten(:, :) = 0.1_kind_phys
     rucuten(:, :) = 0.1_kind_phys
@@ -315,60 +366,85 @@ subroutine test_mmm_physics_accumulate_tendencies_run()
 
     rthblten(:, :) = 0.1_kind_phys
     rthcuten(:, :) = 0.1_kind_phys
+    rthmpten(:, :) = 0.1_kind_phys
     rthratenlw(:, :) = 0.1_kind_phys
     rthratensw(:, :) = 0.1_kind_phys
 
     rqvblten(:, :) = 0.00025_kind_phys
     rqvcuten(:, :) = 0.00025_kind_phys
+    rqvmpten(:, :) = 0.00025_kind_phys
 
     rqcblten(:, :) = 0.00025_kind_phys
     rncblten(:, :) = 25000.0_kind_phys
     rqccuten(:, :) = 0.00025_kind_phys
+    rqcmpten(:, :) = 0.00025_kind_phys
+    rncmpten(:, :) = 25000.0_kind_phys
+
+    rqrmpten(:, :) = 0.00025_kind_phys
+    rnrmpten(:, :) = 25000.0_kind_phys
 
     rqiblten(:, :) = 0.00025_kind_phys
     rniblten(:, :) = 250.0_kind_phys
     rqicuten(:, :) = 0.00025_kind_phys
+    rqimpten(:, :) = 0.00025_kind_phys
+    rnimpten(:, :) = 250.0_kind_phys
 
     rqsblten(:, :) = 0.00025_kind_phys
+    rqsmpten(:, :) = 0.00025_kind_phys
+
+    rqgmpten(:, :) = 0.00025_kind_phys
+    rngmpten(:, :) = 250.0_kind_phys
+    rvolgmpten(:, :) = 0.00025_kind_phys
 
     rozblten(:, :) = 2.5E-10_kind_phys
 
     rnwfablten(:, :) = 25000.0_kind_phys
+    rnwfampten(:, :) = 25000.0_kind_phys
     rnifablten(:, :) = 25000.0_kind_phys
+    rnifampten(:, :) = 25000.0_kind_phys
     rnbcablten(:, :) = 25000.0_kind_phys
 
     call mmm_physics_accumulate_tendencies_run( &
         dt, exner, &
         dudt, dvdt, dtdt, &
-        theta, qv, qc, qi, qs, ozone, &
-        nc, ni, nwfa, nifa, nbca, &
+        theta, qv, qc, qr, qi, qs, qg, ozone, &
+        nc, nr, ni, ng, nwfa, nifa, nbca, &
+        volg, &
         rublten, rucuten, rvblten, rvcuten, &
-        rthblten, rthcuten, rthratenlw, rthratensw, &
-        rqvblten, rqvcuten, &
-        rqcblten, rncblten, rqccuten, &
-        rqiblten, rniblten, rqicuten, &
-        rqsblten, &
+        rthblten, rthcuten, rthmpten, rthratenlw, rthratensw, &
+        rqvblten, rqvcuten, rqvmpten, &
+        rqcblten, rncblten, rqccuten, rqcmpten, rncmpten, &
+        rqrmpten, rnrmpten, &
+        rqiblten, rniblten, rqicuten, rqimpten, rnimpten, &
+        rqsblten, rqsmpten, &
+        rqgmpten, rngmpten, rvolgmpten, &
         rozblten, &
-        rnwfablten, rnifablten, rnbcablten, &
+        rnwfablten, rnwfampten, rnifablten, rnifampten, rnbcablten, &
         errmsg, errflg)
 
     ! Should accumulate MMM tendencies into the equivalent CAM-SIMA ones correctly.
     @assertEqual(0.2_kind_phys, dudt, spacing(0.2_kind_phys))
     @assertEqual(0.2_kind_phys, dvdt, spacing(0.2_kind_phys))
-    @assertEqual(0.4_kind_phys, dtdt, spacing(0.4_kind_phys))
+    @assertEqual(0.5_kind_phys, dtdt, spacing(0.5_kind_phys))
 
-    @assertEqual(281.15_kind_phys, theta, spacing(281.15_kind_phys))
-    @assertEqual(0.02_kind_phys, qv, spacing(0.02_kind_phys))
-    @assertEqual(0.02_kind_phys, qc, spacing(0.02_kind_phys))
-    @assertEqual(0.02_kind_phys, qi, spacing(0.02_kind_phys))
-    @assertEqual(0.015_kind_phys, qs, spacing(0.015_kind_phys))
+    @assertEqual(283.15_kind_phys, theta, spacing(283.15_kind_phys))
+    @assertEqual(0.025_kind_phys, qv, spacing(0.025_kind_phys))
+    @assertEqual(0.025_kind_phys, qc, spacing(0.025_kind_phys))
+    @assertEqual(0.015_kind_phys, qr, spacing(0.015_kind_phys))
+    @assertEqual(0.025_kind_phys, qi, spacing(0.025_kind_phys))
+    @assertEqual(0.02_kind_phys, qs, spacing(0.02_kind_phys))
+    @assertEqual(0.015_kind_phys, qg, spacing(0.015_kind_phys))
     @assertEqual(1.5E-8_kind_phys, ozone, spacing(1.5E-8_kind_phys))
 
-    @assertEqual(1.005E8_kind_phys, nc, spacing(1.005E8_kind_phys))
-    @assertEqual(1.005E6_kind_phys, ni, spacing(1.005E6_kind_phys))
-    @assertEqual(1.005E8_kind_phys, nwfa, spacing(1.005E8_kind_phys))
-    @assertEqual(1.005E8_kind_phys, nifa, spacing(1.005E8_kind_phys))
+    @assertEqual(1.01E8_kind_phys, nc, spacing(1.01E8_kind_phys))
+    @assertEqual(1.005E8_kind_phys, nr, spacing(1.005E8_kind_phys))
+    @assertEqual(1.01E6_kind_phys, ni, spacing(1.01E6_kind_phys))
+    @assertEqual(1.005E6_kind_phys, ng, spacing(1.01E6_kind_phys))
+    @assertEqual(1.01E8_kind_phys, nwfa, spacing(1.01E8_kind_phys))
+    @assertEqual(1.01E8_kind_phys, nifa, spacing(1.01E8_kind_phys))
     @assertEqual(1.005E8_kind_phys, nbca, spacing(1.005E8_kind_phys))
+
+    @assertEqual(0.015_kind_phys, volg, spacing(0.015_kind_phys))
 
     ! After accumulating, MMM tendencies should be zeroed out.
     @assertEqual(0.0_kind_phys, rublten)
@@ -378,26 +454,42 @@ subroutine test_mmm_physics_accumulate_tendencies_run()
 
     @assertEqual(0.0_kind_phys, rthblten)
     @assertEqual(0.0_kind_phys, rthcuten)
+    @assertEqual(0.0_kind_phys, rthmpten)
     @assertEqual(0.0_kind_phys, rthratenlw)
     @assertEqual(0.0_kind_phys, rthratensw)
 
     @assertEqual(0.0_kind_phys, rqvblten)
     @assertEqual(0.0_kind_phys, rqvcuten)
+    @assertEqual(0.0_kind_phys, rqvmpten)
 
     @assertEqual(0.0_kind_phys, rqcblten)
     @assertEqual(0.0_kind_phys, rncblten)
     @assertEqual(0.0_kind_phys, rqccuten)
+    @assertEqual(0.0_kind_phys, rqcmpten)
+    @assertEqual(0.0_kind_phys, rncmpten)
+
+    @assertEqual(0.0_kind_phys, rqrmpten)
+    @assertEqual(0.0_kind_phys, rnrmpten)
 
     @assertEqual(0.0_kind_phys, rqiblten)
     @assertEqual(0.0_kind_phys, rniblten)
     @assertEqual(0.0_kind_phys, rqicuten)
+    @assertEqual(0.0_kind_phys, rqimpten)
+    @assertEqual(0.0_kind_phys, rnimpten)
 
     @assertEqual(0.0_kind_phys, rqsblten)
+    @assertEqual(0.0_kind_phys, rqsmpten)
+
+    @assertEqual(0.0_kind_phys, rqgmpten)
+    @assertEqual(0.0_kind_phys, rngmpten)
+    @assertEqual(0.0_kind_phys, rvolgmpten)
 
     @assertEqual(0.0_kind_phys, rozblten)
 
     @assertEqual(0.0_kind_phys, rnwfablten)
+    @assertEqual(0.0_kind_phys, rnwfampten)
     @assertEqual(0.0_kind_phys, rnifablten)
+    @assertEqual(0.0_kind_phys, rnifampten)
     @assertEqual(0.0_kind_phys, rnbcablten)
 
     @assertEqual('', errmsg)
@@ -410,60 +502,85 @@ subroutine test_mmm_physics_accumulate_tendencies_run()
 
     rthblten(:, :) = 0.1_kind_phys
     rthcuten(:, :) = 0.1_kind_phys
+    rthmpten(:, :) = 0.1_kind_phys
     rthratenlw(:, :) = 0.1_kind_phys
     rthratensw(:, :) = 0.1_kind_phys
 
     rqvblten(:, :) = 0.00025_kind_phys
     rqvcuten(:, :) = 0.00025_kind_phys
+    rqvmpten(:, :) = 0.00025_kind_phys
 
     rqcblten(:, :) = 0.00025_kind_phys
     rncblten(:, :) = 25000.0_kind_phys
     rqccuten(:, :) = 0.00025_kind_phys
+    rqcmpten(:, :) = 0.00025_kind_phys
+    rncmpten(:, :) = 25000.0_kind_phys
+
+    rqrmpten(:, :) = 0.00025_kind_phys
+    rnrmpten(:, :) = 25000.0_kind_phys
 
     rqiblten(:, :) = 0.00025_kind_phys
     rniblten(:, :) = 250.0_kind_phys
     rqicuten(:, :) = 0.00025_kind_phys
+    rqimpten(:, :) = 0.00025_kind_phys
+    rnimpten(:, :) = 250.0_kind_phys
 
     rqsblten(:, :) = 0.00025_kind_phys
+    rqsmpten(:, :) = 0.00025_kind_phys
+
+    rqgmpten(:, :) = 0.00025_kind_phys
+    rngmpten(:, :) = 250.0_kind_phys
+    rvolgmpten(:, :) = 0.00025_kind_phys
 
     rozblten(:, :) = 2.5E-10_kind_phys
 
     rnwfablten(:, :) = 25000.0_kind_phys
+    rnwfampten(:, :) = 25000.0_kind_phys
     rnifablten(:, :) = 25000.0_kind_phys
+    rnifampten(:, :) = 25000.0_kind_phys
     rnbcablten(:, :) = 25000.0_kind_phys
 
     call mmm_physics_accumulate_tendencies_run( &
         dt, exner, &
         dudt, dvdt, dtdt, &
-        theta, qv, qc, qi, qs, ozone, &
-        nc, ni, nwfa, nifa, nbca, &
+        theta, qv, qc, qr, qi, qs, qg, ozone, &
+        nc, nr, ni, ng, nwfa, nifa, nbca, &
+        volg, &
         rublten, rucuten, rvblten, rvcuten, &
-        rthblten, rthcuten, rthratenlw, rthratensw, &
-        rqvblten, rqvcuten, &
-        rqcblten, rncblten, rqccuten, &
-        rqiblten, rniblten, rqicuten, &
-        rqsblten, &
+        rthblten, rthcuten, rthmpten, rthratenlw, rthratensw, &
+        rqvblten, rqvcuten, rqvmpten, &
+        rqcblten, rncblten, rqccuten, rqcmpten, rncmpten, &
+        rqrmpten, rnrmpten, &
+        rqiblten, rniblten, rqicuten, rqimpten, rnimpten, &
+        rqsblten, rqsmpten, &
+        rqgmpten, rngmpten, rvolgmpten, &
         rozblten, &
-        rnwfablten, rnifablten, rnbcablten, &
+        rnwfablten, rnwfampten, rnifablten, rnifampten, rnbcablten, &
         errmsg, errflg)
 
     ! Should accumulate MMM tendencies into the equivalent CAM-SIMA ones correctly.
     @assertEqual(0.4_kind_phys, dudt, spacing(0.4_kind_phys))
     @assertEqual(0.4_kind_phys, dvdt, spacing(0.4_kind_phys))
-    @assertEqual(0.8_kind_phys, dtdt, spacing(0.8_kind_phys))
+    @assertEqual(1.0_kind_phys, dtdt, spacing(1.0_kind_phys))
 
-    @assertEqual(289.15_kind_phys, theta, spacing(289.15_kind_phys))
-    @assertEqual(0.03_kind_phys, qv, spacing(0.03_kind_phys))
-    @assertEqual(0.03_kind_phys, qc, spacing(0.03_kind_phys))
-    @assertEqual(0.03_kind_phys, qi, spacing(0.03_kind_phys))
-    @assertEqual(0.02_kind_phys, qs, spacing(0.02_kind_phys))
+    @assertEqual(293.15_kind_phys, theta, spacing(293.15_kind_phys))
+    @assertEqual(0.04_kind_phys, qv, spacing(0.04_kind_phys))
+    @assertEqual(0.04_kind_phys, qc, spacing(0.04_kind_phys))
+    @assertEqual(0.02_kind_phys, qr, spacing(0.02_kind_phys))
+    @assertEqual(0.04_kind_phys, qi, spacing(0.04_kind_phys))
+    @assertEqual(0.03_kind_phys, qs, spacing(0.03_kind_phys))
+    @assertEqual(0.02_kind_phys, qg, spacing(0.02_kind_phys))
     @assertEqual(2.0E-8_kind_phys, ozone, spacing(2.0E-8_kind_phys))
 
-    @assertEqual(1.01E8_kind_phys, nc, spacing(1.01E8_kind_phys))
-    @assertEqual(1.01E6_kind_phys, ni, spacing(1.01E6_kind_phys))
-    @assertEqual(1.01E8_kind_phys, nwfa, spacing(1.01E8_kind_phys))
-    @assertEqual(1.01E8_kind_phys, nifa, spacing(1.01E8_kind_phys))
+    @assertEqual(1.02E8_kind_phys, nc, spacing(1.02E8_kind_phys))
+    @assertEqual(1.01E8_kind_phys, nr, spacing(1.01E8_kind_phys))
+    @assertEqual(1.02E6_kind_phys, ni, spacing(1.02E6_kind_phys))
+    @assertEqual(1.01E6_kind_phys, ng, spacing(1.01E6_kind_phys))
+    @assertEqual(1.02E8_kind_phys, nwfa, spacing(1.02E8_kind_phys))
+    @assertEqual(1.02E8_kind_phys, nifa, spacing(1.02E8_kind_phys))
     @assertEqual(1.01E8_kind_phys, nbca, spacing(1.01E8_kind_phys))
+
+    @assertEqual(0.02_kind_phys, volg, spacing(0.02_kind_phys))
 
     ! After accumulating, MMM tendencies should be zeroed out.
     @assertEqual(0.0_kind_phys, rublten)
@@ -473,26 +590,42 @@ subroutine test_mmm_physics_accumulate_tendencies_run()
 
     @assertEqual(0.0_kind_phys, rthblten)
     @assertEqual(0.0_kind_phys, rthcuten)
+    @assertEqual(0.0_kind_phys, rthmpten)
     @assertEqual(0.0_kind_phys, rthratenlw)
     @assertEqual(0.0_kind_phys, rthratensw)
 
     @assertEqual(0.0_kind_phys, rqvblten)
     @assertEqual(0.0_kind_phys, rqvcuten)
+    @assertEqual(0.0_kind_phys, rqvmpten)
 
     @assertEqual(0.0_kind_phys, rqcblten)
     @assertEqual(0.0_kind_phys, rncblten)
     @assertEqual(0.0_kind_phys, rqccuten)
+    @assertEqual(0.0_kind_phys, rqcmpten)
+    @assertEqual(0.0_kind_phys, rncmpten)
+
+    @assertEqual(0.0_kind_phys, rqrmpten)
+    @assertEqual(0.0_kind_phys, rnrmpten)
 
     @assertEqual(0.0_kind_phys, rqiblten)
     @assertEqual(0.0_kind_phys, rniblten)
     @assertEqual(0.0_kind_phys, rqicuten)
+    @assertEqual(0.0_kind_phys, rqimpten)
+    @assertEqual(0.0_kind_phys, rnimpten)
 
     @assertEqual(0.0_kind_phys, rqsblten)
+    @assertEqual(0.0_kind_phys, rqsmpten)
+
+    @assertEqual(0.0_kind_phys, rqgmpten)
+    @assertEqual(0.0_kind_phys, rngmpten)
+    @assertEqual(0.0_kind_phys, rvolgmpten)
 
     @assertEqual(0.0_kind_phys, rozblten)
 
     @assertEqual(0.0_kind_phys, rnwfablten)
+    @assertEqual(0.0_kind_phys, rnwfampten)
     @assertEqual(0.0_kind_phys, rnifablten)
+    @assertEqual(0.0_kind_phys, rnifampten)
     @assertEqual(0.0_kind_phys, rnbcablten)
 
     @assertEqual('', errmsg)
@@ -501,50 +634,62 @@ subroutine test_mmm_physics_accumulate_tendencies_run()
     call mmm_physics_accumulate_tendencies_run( &
         dt, exner, &
         dudt, dvdt, dtdt, &
-        theta, qv, qc, qi, qs, ozone, &
-        nc, ni, nwfa, nifa, nbca, &
+        theta, qv, qc, qr, qi, qs, qg, ozone, &
+        nc, nr, ni, ng, nwfa, nifa, nbca, &
+        volg, &
         rublten, rucuten, rvblten, rvcuten, &
-        rthblten, rthcuten, rthratenlw, rthratensw, &
-        rqvblten, rqvcuten, &
-        rqcblten, rncblten, rqccuten, &
-        rqiblten, rniblten, rqicuten, &
-        rqsblten, &
+        rthblten, rthcuten, rthmpten, rthratenlw, rthratensw, &
+        rqvblten, rqvcuten, rqvmpten, &
+        rqcblten, rncblten, rqccuten, rqcmpten, rncmpten, &
+        rqrmpten, rnrmpten, &
+        rqiblten, rniblten, rqicuten, rqimpten, rnimpten, &
+        rqsblten, rqsmpten, &
+        rqgmpten, rngmpten, rvolgmpten, &
         rozblten, &
-        rnwfablten, rnifablten, rnbcablten, &
+        rnwfablten, rnwfampten, rnifablten, rnifampten, rnbcablten, &
         errmsg, errflg)
 
     call mmm_physics_accumulate_tendencies_run( &
         dt, exner, &
         dudt, dvdt, dtdt, &
-        theta, qv, qc, qi, qs, ozone, &
-        nc, ni, nwfa, nifa, nbca, &
+        theta, qv, qc, qr, qi, qs, qg, ozone, &
+        nc, nr, ni, ng, nwfa, nifa, nbca, &
+        volg, &
         rublten, rucuten, rvblten, rvcuten, &
-        rthblten, rthcuten, rthratenlw, rthratensw, &
-        rqvblten, rqvcuten, &
-        rqcblten, rncblten, rqccuten, &
-        rqiblten, rniblten, rqicuten, &
-        rqsblten, &
+        rthblten, rthcuten, rthmpten, rthratenlw, rthratensw, &
+        rqvblten, rqvcuten, rqvmpten, &
+        rqcblten, rncblten, rqccuten, rqcmpten, rncmpten, &
+        rqrmpten, rnrmpten, &
+        rqiblten, rniblten, rqicuten, rqimpten, rnimpten, &
+        rqsblten, rqsmpten, &
+        rqgmpten, rngmpten, rvolgmpten, &
         rozblten, &
-        rnwfablten, rnifablten, rnbcablten, &
+        rnwfablten, rnwfampten, rnifablten, rnifampten, rnbcablten, &
         errmsg, errflg)
 
     ! Consecutive calls should be idempotent.
     @assertEqual(0.4_kind_phys, dudt, spacing(0.4_kind_phys))
     @assertEqual(0.4_kind_phys, dvdt, spacing(0.4_kind_phys))
-    @assertEqual(0.8_kind_phys, dtdt, spacing(0.8_kind_phys))
+    @assertEqual(1.0_kind_phys, dtdt, spacing(1.0_kind_phys))
 
-    @assertEqual(289.15_kind_phys, theta, spacing(289.15_kind_phys))
-    @assertEqual(0.03_kind_phys, qv, spacing(0.03_kind_phys))
-    @assertEqual(0.03_kind_phys, qc, spacing(0.03_kind_phys))
-    @assertEqual(0.03_kind_phys, qi, spacing(0.03_kind_phys))
-    @assertEqual(0.02_kind_phys, qs, spacing(0.02_kind_phys))
+    @assertEqual(293.15_kind_phys, theta, spacing(293.15_kind_phys))
+    @assertEqual(0.04_kind_phys, qv, spacing(0.04_kind_phys))
+    @assertEqual(0.04_kind_phys, qc, spacing(0.04_kind_phys))
+    @assertEqual(0.02_kind_phys, qr, spacing(0.02_kind_phys))
+    @assertEqual(0.04_kind_phys, qi, spacing(0.04_kind_phys))
+    @assertEqual(0.03_kind_phys, qs, spacing(0.03_kind_phys))
+    @assertEqual(0.02_kind_phys, qg, spacing(0.02_kind_phys))
     @assertEqual(2.0E-8_kind_phys, ozone, spacing(2.0E-8_kind_phys))
 
-    @assertEqual(1.01E8_kind_phys, nc, spacing(1.01E8_kind_phys))
-    @assertEqual(1.01E6_kind_phys, ni, spacing(1.01E6_kind_phys))
-    @assertEqual(1.01E8_kind_phys, nwfa, spacing(1.01E8_kind_phys))
-    @assertEqual(1.01E8_kind_phys, nifa, spacing(1.01E8_kind_phys))
+    @assertEqual(1.02E8_kind_phys, nc, spacing(1.02E8_kind_phys))
+    @assertEqual(1.01E8_kind_phys, nr, spacing(1.01E8_kind_phys))
+    @assertEqual(1.02E6_kind_phys, ni, spacing(1.02E6_kind_phys))
+    @assertEqual(1.01E6_kind_phys, ng, spacing(1.01E6_kind_phys))
+    @assertEqual(1.02E8_kind_phys, nwfa, spacing(1.02E8_kind_phys))
+    @assertEqual(1.02E8_kind_phys, nifa, spacing(1.02E8_kind_phys))
     @assertEqual(1.01E8_kind_phys, nbca, spacing(1.01E8_kind_phys))
+
+    @assertEqual(0.02_kind_phys, volg, spacing(0.02_kind_phys))
 
     ! Consecutive calls should be idempotent.
     @assertEqual(0.0_kind_phys, rublten)
@@ -554,26 +699,42 @@ subroutine test_mmm_physics_accumulate_tendencies_run()
 
     @assertEqual(0.0_kind_phys, rthblten)
     @assertEqual(0.0_kind_phys, rthcuten)
+    @assertEqual(0.0_kind_phys, rthmpten)
     @assertEqual(0.0_kind_phys, rthratenlw)
     @assertEqual(0.0_kind_phys, rthratensw)
 
     @assertEqual(0.0_kind_phys, rqvblten)
     @assertEqual(0.0_kind_phys, rqvcuten)
+    @assertEqual(0.0_kind_phys, rqvmpten)
 
     @assertEqual(0.0_kind_phys, rqcblten)
     @assertEqual(0.0_kind_phys, rncblten)
     @assertEqual(0.0_kind_phys, rqccuten)
+    @assertEqual(0.0_kind_phys, rqcmpten)
+    @assertEqual(0.0_kind_phys, rncmpten)
+
+    @assertEqual(0.0_kind_phys, rqrmpten)
+    @assertEqual(0.0_kind_phys, rnrmpten)
 
     @assertEqual(0.0_kind_phys, rqiblten)
     @assertEqual(0.0_kind_phys, rniblten)
     @assertEqual(0.0_kind_phys, rqicuten)
+    @assertEqual(0.0_kind_phys, rqimpten)
+    @assertEqual(0.0_kind_phys, rnimpten)
 
     @assertEqual(0.0_kind_phys, rqsblten)
+    @assertEqual(0.0_kind_phys, rqsmpten)
+
+    @assertEqual(0.0_kind_phys, rqgmpten)
+    @assertEqual(0.0_kind_phys, rngmpten)
+    @assertEqual(0.0_kind_phys, rvolgmpten)
 
     @assertEqual(0.0_kind_phys, rozblten)
 
     @assertEqual(0.0_kind_phys, rnwfablten)
+    @assertEqual(0.0_kind_phys, rnwfampten)
     @assertEqual(0.0_kind_phys, rnifablten)
+    @assertEqual(0.0_kind_phys, rnifampten)
     @assertEqual(0.0_kind_phys, rnbcablten)
 
     @assertEqual('', errmsg)


### PR DESCRIPTION
### Tag name

TBD

### Originator(s)

kuanchihwang

### Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number)

This PR adds the TEMPO microphysics and Xu-Randall cloud fraction schemes to complete the convection-permitting suite.

The main scheme code of TEMPO is pulled directly from [its upstream repository](https://github.com/NCAR/TEMPO) via a Git submodule, pinned at the latest available tag (`tempo_v3.1.2`) as of now. The host model dependent interstitial scheme code is hosted here. The Xu-Randall cloud fraction scheme is CCPP-ized from the MPAS (`calc_cldfraction`) and WRF (`cal_cldfra1`) implementations with a slight rewrite to improve readability.

### List all namelist files that have been modified

```
A       schemes/tempo/mp_tempo_namelist.xml
  * Add namelist definition for TEMPO
```

### List all files eliminated and why

None

### List all files added and what they do

```
A       schemes/mmm/cldfra_xu_randall.F90
A       schemes/mmm/cldfra_xu_randall.meta
A       schemes/mmm/cldfra_xu_randall_diag.F90
A       schemes/mmm/cldfra_xu_randall_diag.meta
  * Add Xu-Randall cloud fraction scheme
A       schemes/tempo/machine.F90
  * Add compatibility module for real kind parameters
A       schemes/tempo/module_mp_tempo_cfgs.F90
A       schemes/tempo/module_mp_tempo_cfgs.meta
  * Add default configuration module for TEMPO
A       schemes/tempo/mp_tempo.F90
A       schemes/tempo/mp_tempo.meta
  * Add interstitial schemes for TEMPO
A       schemes/tempo/mp_tempo_diag.F90
A       schemes/tempo/mp_tempo_diag.meta
  * Add diagnostic schemes for TEMPO
A       schemes/tempo/tempo
  * Add git submodule for TEMPO
```

### List all existing files that have been modified, and describe the changes

```
M       .gitmodules
  * Add git submodule for TEMPO
M       schemes/mmm/ccpp_kind_types.F90
  * Add compatibility module for real kind parameters
M       schemes/mmm/mmm_physics_compat.F90
M       schemes/mmm/mmm_physics_compat.meta
  * Fix build error in debug mode
  * Add interstitial schemes to capture microphysics tendencies
M       schemes/utilities/state_converters.F90
M       schemes/utilities/state_converters.meta
  * Add graupel conversion between dry and wet
M       test/test_suites/suite_convection_permitting.xml
  * Update SDF
M       test/unit-test/tests/mmm/mmm_physics_compat_tests.pf
  * Fix unit tests
```

### List all automated tests that failed, as well as an explanation for why they were not fixed

All pass.

### Is this an answer-changing PR? If so, is it a new physics package, algorithm change, tuning change, etc?

Yes, but only for the convection-permitting suite.

### If yes to the above question, describe how this code was validated with the new/modified features

Pending science validation.